### PR TITLE
Fixed popcount returning 0 in all 1 values

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2937,4 +2937,42 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn popcount() -> Result<()> {
+        for n in 0..=8u8 {
+            let value: u8 = ((1u16 << n) - 1) as u8;
+            let mut emulator = PcodeEmulator::new(vec![processor_address_space()]);
+            let lhs_input = write_bytes(&mut emulator, 0, vec![value.into()])?;
+
+            let output = VarnodeData {
+                address: Address {
+                    address_space: processor_address_space(),
+                    offset: 2,
+                },
+                size: 1,
+            };
+
+            let instruction = PcodeInstruction {
+                address: Address {
+                    address_space: processor_address_space(),
+                    offset: 0xFF00000000,
+                },
+                op_code: OpCode::CPUI_POPCOUNT,
+                inputs: vec![lhs_input.clone()],
+                output: Some(output.clone()),
+            };
+
+            emulator.emulate(&instruction)?;
+            let expected_result = n;
+
+            assert_eq!(
+                emulator.memory.read_concrete_value::<u8>(&output)?,
+                expected_result,
+                "failed popcount of {value:#02x}"
+            );
+        }
+
+        Ok(())
+    }
 }

--- a/sym/src/sym.rs
+++ b/sym/src/sym.rs
@@ -634,10 +634,9 @@ impl SymbolicBitVec {
         let len = if self.len() == 0 {
             // This special case is needed to avoid taking log2 of 0
             1
-        } else if self.len().is_power_of_two() {
-            self.len().ilog2() as usize
         } else {
-            // Add 1 if not power of 2 since ilog2 rounds down
+            // ilog2 rounds down. If it rounds down, need to add 1. If it is a power of 2 then also
+            // need to add 1 to account for if all bits are set
             self.len().ilog2() as usize + 1
         };
 
@@ -1282,7 +1281,7 @@ mod tests {
 
     #[test]
     fn popcount() {
-        for n in 0..8 {
+        for n in 0..=8 {
             let value = SymbolicBitVec::constant((1 << n) - 1, 8);
             let popcount = value.popcount();
             let popcount: u8 = popcount.try_into().expect("failed converison");


### PR DESCRIPTION
The bug was caused by using `self.len().ilog2()` instead of `ilog2() + 1` whenever the length was a power of two. Suppose for example the length is `8`, a power of two. Then the popcount of `0b1111_1111` is `8 = 0b1000` which requires `4` bits to represent. So we need to use `ilog2() + 1` when it's a power of two.