### PR TITLE
Pass memory as a parameter to emulator instead of owning it

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1007,7 +1007,8 @@ impl StandardPcodeEmulator {
         require_has_output(&instruction, false)?;
 
         // Constant address space indicates a p-code relative branch.
-        if instruction.address.address_space.space_type == AddressSpaceType::Constant {
+        let address_space = &instruction.address.address_space;
+        if address_space.space_type == AddressSpaceType::Constant {
             return Err(Error::IllegalInstruction {
                 instruction: instruction.clone(),
                 reason: format!(
@@ -1017,11 +1018,10 @@ impl StandardPcodeEmulator {
             });
         }
 
-        let offset =
-            Self::indirect_offset(memory, instruction, 0, &instruction.address.address_space)?;
+        let offset = Self::indirect_offset(memory, instruction, 0, address_space)?;
 
         Ok(ControlFlow::Jump(Destination::MachineAddress(Address {
-            address_space: instruction.address.address_space.clone(),
+            address_space: address_space.clone(),
             offset,
         })))
     }


### PR DESCRIPTION
Requiring the emulator to own the memory module complicates some broader goals. For example, if we want to support a memory implementation that performs lookups in a different memory module whenever data is unavailable in the main module, the emulator would have to own *both* modules. But this fallback module could be part of a larger existing architecture that never anticipated sharing its ownership.

So instead the emulator has been changed to instead accept a mutable memory reference for the `emulate` function. This means the default emulator is now stateless.