### PR TITLE
Remove stored address spaces from memory

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1501,7 +1501,7 @@ mod tests {
 
     #[test]
     fn copy() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
         let data = vec![0xEFu8.into(), 0xBEu8.into(), 0xADu8.into(), 0xDEu8.into()];
@@ -1539,7 +1539,7 @@ mod tests {
 
     #[test]
     fn load() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -1601,7 +1601,7 @@ mod tests {
 
     #[test]
     fn store() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -1667,7 +1667,7 @@ mod tests {
 
     #[test]
     fn int_sub() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -1728,7 +1728,7 @@ mod tests {
 
         for (lhs, rhs, expected_result) in test_data {
             let expected_result = if expected_result { 1 } else { 0 };
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -1765,7 +1765,7 @@ mod tests {
 
     #[test]
     fn int_add() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -1816,7 +1816,7 @@ mod tests {
     fn int_multiply() -> Result<()> {
         for lhs in 0..16u8 {
             for rhs in 0..16u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_value = SymbolicBitVec::constant(lhs.into(), 4);
                 let lhs_value = lhs_value.zero_extend(4).into_bytes().pop().unwrap();
@@ -1859,7 +1859,7 @@ mod tests {
 
     #[test]
     fn int_multiply_multibyte() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let lhs: u8 = 0xFF;
         let lhs_value: SymbolicBitVec = lhs.into();
@@ -1904,7 +1904,7 @@ mod tests {
     fn int_divide() -> Result<()> {
         for lhs in 0..16u8 {
             for rhs in 1..16u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_value: SymbolicByte = lhs.into();
                 let lhs_input = write_bytes(&mut memory, 0, vec![lhs_value])?;
@@ -1948,7 +1948,7 @@ mod tests {
     fn int_remainder() -> Result<()> {
         for lhs in 0..16u8 {
             for rhs in 1..16u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_value: SymbolicByte = lhs.into();
                 let lhs_input = write_bytes(&mut memory, 0, vec![lhs_value])?;
@@ -1992,7 +1992,7 @@ mod tests {
     fn int_signed_divide() -> Result<()> {
         for lhs in 0..16u8 {
             for rhs in 1..16u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_value = SymbolicBitVec::constant(lhs.into(), 4)
                     .sign_extend(4)
@@ -2048,7 +2048,7 @@ mod tests {
     fn int_signed_remainder() -> Result<()> {
         for lhs in 0..16u8 {
             for rhs in 1..16u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_value = SymbolicBitVec::constant(lhs.into(), 4)
                     .sign_extend(4)
@@ -2102,7 +2102,7 @@ mod tests {
 
     #[test]
     fn int_zext() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -2141,7 +2141,7 @@ mod tests {
 
     #[test]
     fn int_sext() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -2209,7 +2209,7 @@ mod tests {
 
     #[test]
     fn int_equal() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -2273,7 +2273,7 @@ mod tests {
 
     #[test]
     fn int_not_equal() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -2336,7 +2336,7 @@ mod tests {
 
     #[test]
     fn piece() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let msb_input = write_bytes(&mut memory, 0, vec![0xADu8.into(), 0xDEu8.into()])?;
         let lsb_input = write_bytes(&mut memory, 2, vec![0xEFu8.into(), 0xBEu8.into()])?;
@@ -2367,7 +2367,7 @@ mod tests {
 
     #[test]
     fn subpiece() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space(), unique_address_space()]);
+        let mut memory = Memory::new();
         let emulator =
             StandardPcodeEmulator::new(vec![processor_address_space(), unique_address_space()]);
 
@@ -2438,7 +2438,7 @@ mod tests {
 
     #[test]
     fn branch_ind() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let data = vec![0xEFu8.into(), 0xBEu8.into(), 0xADu8.into(), 0xDEu8.into()];
         let data_input = write_bytes(&mut memory, 0, data)?;
@@ -2462,7 +2462,7 @@ mod tests {
 
     #[test]
     fn call_ind() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let data = vec![0xEFu8.into(), 0xBEu8.into(), 0xADu8.into(), 0xDEu8.into()];
         let data_input = write_bytes(&mut memory, 0, data)?;
@@ -2488,7 +2488,7 @@ mod tests {
     #[test]
     fn bool_negate() -> Result<()> {
         for value in 0..=1u8 {
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let input = write_bytes(&mut memory, 0, vec![value.into()])?;
 
@@ -2526,7 +2526,7 @@ mod tests {
     fn bool_and() -> Result<()> {
         for lhs in 0..=1u8 {
             for rhs in 0..=1u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
                 let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -2566,7 +2566,7 @@ mod tests {
     fn bool_or() -> Result<()> {
         for lhs in 0..=1u8 {
             for rhs in 0..=1u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
                 let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -2606,7 +2606,7 @@ mod tests {
     fn bool_xor() -> Result<()> {
         for lhs in 0..=1u8 {
             for rhs in 0..=1u8 {
-                let mut memory = Memory::new(vec![processor_address_space()]);
+                let mut memory = Memory::new();
                 let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
                 let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
                 let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -2644,7 +2644,7 @@ mod tests {
 
     #[test]
     fn int_negate() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let lhs = 0b1010_0101;
         let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
@@ -2680,7 +2680,7 @@ mod tests {
 
     #[test]
     fn int_2comp() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let lhs = 1u8;
         let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
@@ -2716,7 +2716,7 @@ mod tests {
 
     #[test]
     fn int_and() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let lhs = 0b0011_1100;
         let rhs = 0b1010_0101;
@@ -2754,7 +2754,7 @@ mod tests {
 
     #[test]
     fn int_or() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let lhs = 0b0011_1100;
         let rhs = 0b1010_0101;
@@ -2792,7 +2792,7 @@ mod tests {
 
     #[test]
     fn int_xor() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let lhs = 0b1111_0000_0011_1100;
         let rhs = 0b0000_1111_1010_0101;
@@ -2838,7 +2838,7 @@ mod tests {
         ];
         for (lhs, rhs, expected_result) in test_data {
             let expected_result = if expected_result { 1 } else { 0 };
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -2883,7 +2883,7 @@ mod tests {
         ];
         for (lhs, rhs, expected_result) in test_data {
             let expected_result = if expected_result { 1 } else { 0 };
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -2928,7 +2928,7 @@ mod tests {
         ];
         for (lhs, rhs, expected_result) in test_data {
             let expected_result = if expected_result { 1 } else { 0 };
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -2973,7 +2973,7 @@ mod tests {
         ];
         for (lhs, rhs, expected_result) in test_data {
             let expected_result = if expected_result { 1 } else { 0 };
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![lhs.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![rhs.into()])?;
@@ -3011,7 +3011,7 @@ mod tests {
     #[test]
     fn shift_left() -> Result<()> {
         for n in 0..=8u8 {
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![0x01u8.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![n.into()])?;
@@ -3050,7 +3050,7 @@ mod tests {
     #[test]
     fn shift_right() -> Result<()> {
         for n in 0..=8u8 {
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![0x80u8.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![n.into()])?;
@@ -3089,7 +3089,7 @@ mod tests {
     #[test]
     fn signed_shift_right() -> Result<()> {
         for n in 0..=8u8 {
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![0x80u8.into()])?;
             let rhs_input = write_bytes(&mut memory, 1, vec![n.into()])?;
@@ -3127,7 +3127,7 @@ mod tests {
 
     #[test]
     fn call() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let data_input = VarnodeData {
             address: Address {
@@ -3159,7 +3159,7 @@ mod tests {
 
     #[test]
     fn branch_absolute() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let data_input = VarnodeData {
             address: Address {
@@ -3191,7 +3191,7 @@ mod tests {
 
     #[test]
     fn branch_pcode_relative() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let data_input = VarnodeData {
             address: Address {
@@ -3220,7 +3220,7 @@ mod tests {
 
     #[test]
     fn conditional_branch_absolute() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let destination_input = VarnodeData {
             address: Address {
@@ -3262,7 +3262,7 @@ mod tests {
 
     #[test]
     fn conditional_branch_pcode_relative() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let destination_input = VarnodeData {
             address: Address {
@@ -3303,7 +3303,7 @@ mod tests {
     fn popcount() -> Result<()> {
         for n in 0..=8u8 {
             let value: u8 = ((1u16 << n) - 1) as u8;
-            let mut memory = Memory::new(vec![processor_address_space()]);
+            let mut memory = Memory::new();
             let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
             let lhs_input = write_bytes(&mut memory, 0, vec![value.into()])?;
 
@@ -3340,7 +3340,7 @@ mod tests {
 
     #[test]
     fn unsupported_opcode() -> Result<()> {
-        let mut memory = Memory::new(vec![processor_address_space()]);
+        let mut memory = Memory::new();
         let emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
         let instruction = PcodeInstruction {
             address: Address {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -44,7 +44,7 @@ pub struct Processor {
 impl Processor {
     pub fn new(sleigh: Sleigh) -> Self {
         Processor {
-            memory: crate::mem::Memory::new(sleigh.address_spaces()),
+            memory: crate::mem::Memory::new(),
             emulator: StandardPcodeEmulator::new(sleigh.address_spaces()),
             sleigh,
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,7 +16,7 @@ impl Processor {
     pub fn new() -> Self {
         let sleigh = x86_64_sleigh();
         let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
-        let memory = Memory::new(sleigh.address_spaces());
+        let memory = Memory::new();
 
         Processor {
             sleigh,


### PR DESCRIPTION
The emulator now handles all address lookup indirection. As a result the memory module no longer needs to keep a record of the `AddressSpace` to construct an address for `Load` and `Store` instructions.

As a result, the memory module will now write to any address provided, even if the address space is not one of the known address spaces from Sleigh. It is the responsibility of the caller to validate the address and enforce any additional restrictions that are desired.

This additional validation is not currently performed except in the case of an indirect address lookup. In those cases the target `Address` must be constructed, including its `AddressSpace`, thereby ensuring the `AddressSpace` is valid.