### PR TITLE
Removed instruction tracing requirement from test processor

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -171,7 +171,7 @@ impl PcodeEmulator for StandardPcodeEmulator {
 }
 
 impl StandardPcodeEmulator {
-    pub fn new(address_spaces: Vec<AddressSpace>) -> Self {
+    pub fn new(address_spaces: impl IntoIterator<Item = AddressSpace>) -> Self {
         Self {
             address_spaces_by_id: address_spaces
                 .into_iter()

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,6 +1,6 @@
 use thiserror;
 
-use crate::emulator::{ControlFlow, Destination, PcodeEmulator, StandardPcodeEmulator};
+use crate::emulator::{ControlFlow, Destination, PcodeEmulator};
 use crate::mem::SymbolicMemory;
 use sla::{Address, AddressSpace, Sleigh, VarnodeData};
 use sym::{SymbolicBit, SymbolicByte};
@@ -35,23 +35,27 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub struct Processor {
+pub struct Processor<E: PcodeEmulator> {
     sleigh: Sleigh,
     memory: crate::mem::Memory,
-    emulator: StandardPcodeEmulator,
+    emulator: E,
 }
 
-impl Processor {
-    pub fn new(sleigh: Sleigh) -> Self {
+impl<E: PcodeEmulator> Processor<E> {
+    pub fn new(sleigh: Sleigh, emulator: E) -> Self {
         Processor {
             memory: crate::mem::Memory::new(),
-            emulator: StandardPcodeEmulator::new(sleigh.address_spaces()),
+            emulator,
             sleigh,
         }
     }
 
     pub fn sleigh(&self) -> &Sleigh {
         &self.sleigh
+    }
+
+    pub fn emulator(&self) -> &E {
+        &self.emulator
     }
 
     pub fn write_register_concrete(

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -161,7 +161,9 @@ fn pcode_coverage() -> Result<(), String> {
     assert_eq!(rax, 0);
 
     processor
+        .emulator()
         .executed_instructions()
+        .into_iter()
         .for_each(|(opcode, count)| println!("Executed {opcode:?}: {count}"));
 
     // Currently the following p-code instructions are not covered by this test:
@@ -170,6 +172,13 @@ fn pcode_coverage() -> Result<(), String> {
     // Bool(Xor)
     // Int(LessThanOrEqual(Signed))
     // Int(LessThanOrEqual(Unsigned))
-    assert_eq!(processor.executed_instructions().count(), 38);
+    assert_eq!(
+        processor
+            .emulator()
+            .executed_instructions()
+            .into_iter()
+            .count(),
+        38
+    );
     Ok(())
 }


### PR DESCRIPTION
This moves the testing environment a step closer to being able to use the `Processor` defined under `src`