### PR TITLE
Properly handle exception in `sla::register_from_name` by returning `Result`

### DIFF
--- a/sla/src/ffi/sys.rs
+++ b/sla/src/ffi/sys.rs
@@ -302,7 +302,7 @@ mod default {
 
         // TODO Change this to return Result<..> since exception thrown on invalid name
         #[rust_name = "register_from_name"]
-        fn getRegister<'a>(self: &'a SleighProxy, name: &CxxString) -> &'a VarnodeData;
+        fn getRegister<'a>(self: &'a SleighProxy, name: &CxxString) -> Result<&'a VarnodeData>;
 
         #[rust_name = "register_name"]
         unsafe fn getRegisterNameProxy(

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -346,9 +346,15 @@ impl Sleigh {
         None
     }
 
-    pub fn register_from_name(&self, name: impl AsRef<str>) -> VarnodeData {
+    pub fn register_from_name(
+        &self,
+        name: impl AsRef<str>,
+    ) -> std::result::Result<VarnodeData, String> {
         let_cxx_string!(name = name.as_ref());
-        self.sleigh.register_from_name(&name).into()
+        self.sleigh
+            .register_from_name(&name)
+            .map(VarnodeData::from)
+            .map_err(|err| format!("failed to get register {name}: {err}"))
     }
 
     ///

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -598,7 +598,7 @@ mod tests {
             .initialize(&sleigh_spec, &processor_spec)
             .expect("Failed to initialize sleigh");
 
-        let rax = sleigh.register_from_name("RAX");
+        let rax = sleigh.register_from_name("RAX").expect("invalid register");
         assert_eq!(rax.address.address_space.name, "register");
         assert_eq!(rax.address.offset, 0);
         assert_eq!(rax.size, 8);

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -61,8 +61,11 @@ impl<E: PcodeEmulator, M: SymbolicMemory> Processor<E, M> {
         &self.emulator
     }
 
-    pub fn register(&self, name: impl AsRef<str>) -> VarnodeData {
-        self.sleigh.register_from_name(name)
+    pub fn register(&self, name: impl AsRef<str>) -> Result<VarnodeData> {
+        let name = name.as_ref();
+        self.sleigh
+            .register_from_name(name)
+            .map_err(|err| Error::InvalidArgument(format!("invalid register {name}: {err}")))
     }
 
     pub fn address_space(&self, name: impl AsRef<str>) -> Result<AddressSpace> {
@@ -79,7 +82,7 @@ impl<E: PcodeEmulator, M: SymbolicMemory> Processor<E, M> {
     }
 
     pub fn read_register(&self, name: impl AsRef<str>) -> Result<Vec<SymbolicByte>> {
-        let register = self.register(name);
+        let register = self.register(name)?;
         let result = self.memory.read(&register)?;
         Ok(result)
     }
@@ -89,7 +92,7 @@ impl<E: PcodeEmulator, M: SymbolicMemory> Processor<E, M> {
         name: impl AsRef<str>,
         data: impl ExactSizeIterator<Item = impl Into<SymbolicByte>>,
     ) -> Result<()> {
-        let register = self.register(name);
+        let register = self.register(name)?;
         let result = self.memory.write(&register, data)?;
         Ok(result)
     }

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -37,7 +37,7 @@ fn processor_with_image(image: impl AsRef<Path>, entry: u64) -> Processor<Tracin
         .expect("failed to write image into memory");
 
     // Init RIP to entry
-    let rip = processor.register("RIP");
+    let rip = processor.register("RIP").expect("invalid register");
     let data = entry.to_le_bytes().into_iter().map(SymbolicByte::from);
     processor
         .memory_mut()
@@ -45,7 +45,7 @@ fn processor_with_image(image: impl AsRef<Path>, entry: u64) -> Processor<Tracin
         .expect("failed to initialize RIP");
 
     // Init RBP to magic EXIT_RIP value
-    let rbp = processor.register("RBP");
+    let rbp = processor.register("RBP").expect("invalid register");
     let data = EXIT_RIP.to_le_bytes().into_iter().map(SymbolicByte::from);
     processor
         .memory_mut()
@@ -66,7 +66,7 @@ fn processor_with_image(image: impl AsRef<Path>, entry: u64) -> Processor<Tracin
         .expect("failed to initialize stack");
 
     // Init RSP to stack address
-    let rsp = processor.register("RSP");
+    let rsp = processor.register("RSP").expect("invalid register");
     let data = INITIAL_STACK
         .to_le_bytes()
         .into_iter()


### PR DESCRIPTION
Resolves #101 