### PR TITLE
Added Sleigh trait and improved Sleigh errors

### DIFF
--- a/sla/Cargo.toml
+++ b/sla/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 cxx = "1.0"
+thiserror = "1.0"
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -478,16 +478,6 @@ impl GhidraSleigh {
 
         Ok(source)
     }
-
-    ///
-    ///
-    /// # Safety
-    ///
-    /// The `space_id` must be a valid identifier obtained from a live pcode dump. This identifier
-    /// is NOT portable between sessions.
-    pub unsafe fn address_space(&self, space_id: usize) -> AddressSpace {
-        AddressSpace::from(&*(space_id as *const sys::AddrSpace))
-    }
 }
 
 impl Sleigh for GhidraSleigh {

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -14,6 +14,23 @@ pub enum Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+// TODO Rename this to Sleigh and current Sleigh to GhidraSleigh
+pub trait Slegh {
+    /// Get the default address space for code execution
+    fn default_code_space(&self) -> AddressSpace;
+
+    /// List all available address spaces
+    fn address_spaces(&self) -> Vec<AddressSpace>;
+
+    fn register_from_name(&self, name: impl AsRef<str>) -> Result<VarnodeData>;
+
+    fn disassemble_pcode(
+        &self,
+        loader: &dyn LoadImage,
+        address: &Address,
+    ) -> std::result::Result<PcodeResponse, String>;
+}
+
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Address {
     /// The standard interpretation of the offset is an index into the associated address space.

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -12,7 +12,6 @@ use crate::opcodes::OpCode;
 
 static INIT: Once = Once::new();
 
-// TODO. Need to replace string errors with sleigh errors
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("insufficient data at varnode {0}")]

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -246,7 +246,7 @@ pub struct Disassembly<T> {
     /// The disassembled instructions
     instructions: Vec<T>,
 
-    /// The instructions origin
+    /// The origin of the instructions
     origin: VarnodeData,
 }
 

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -12,6 +12,8 @@ use crate::opcodes::OpCode;
 
 static INIT: Once = Once::new();
 
+/// Errors returned by this crate. Note that some APIs that may pass through FFI boundaries return
+/// [String] since those errors are ultimately serialized anyway.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("insufficient data at varnode {0}")]

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -10,6 +10,7 @@ use cxx::{let_cxx_string, UniquePtr};
 
 static INIT: Once = Once::new();
 
+// TODO. Need to replace string errors with sleigh errors
 pub enum Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -496,7 +497,6 @@ impl Sleigh for GhidraSleigh {
             .map_err(|err| format!("failed to get register {name}: {err}"))
     }
 
-    #[must_use]
     fn disassemble_pcode(
         &self,
         loader: &dyn LoadImage,
@@ -508,7 +508,6 @@ impl Sleigh for GhidraSleigh {
         Ok(Disassembly::new(instructions, origin))
     }
 
-    #[must_use]
     fn disassemble_native(
         &self,
         loader: &dyn LoadImage,

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -14,8 +14,7 @@ pub enum Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-// TODO Rename this to Sleigh and current Sleigh to GhidraSleigh
-pub trait Slegh {
+pub trait Sleigh {
     /// Get the default address space for code execution
     fn default_code_space(&self) -> AddressSpace;
 
@@ -311,7 +310,7 @@ pub trait LoadImage {
     fn instruction_bytes(&self, data: &VarnodeData) -> std::result::Result<Vec<u8>, String>;
 }
 
-pub struct Sleigh {
+pub struct GhidraSleigh {
     /// The sleigh object. This object holds a reference to the image loader.
     sleigh: UniquePtr<sys::SleighProxy>,
 }
@@ -321,7 +320,7 @@ enum DisassemblyKind<'a> {
     Pcode(&'a mut Vec<PcodeInstruction>),
 }
 
-impl Sleigh {
+impl GhidraSleigh {
     pub fn new() -> Self {
         Self {
             sleigh: sys::new_sleigh(sys::new_context_internal()),
@@ -436,7 +435,7 @@ impl Sleigh {
     }
 }
 
-impl Slegh for Sleigh {
+impl Sleigh for GhidraSleigh {
     fn default_code_space(&self) -> AddressSpace {
         unsafe { &*self.sleigh.default_code_space() }.into()
     }
@@ -538,7 +537,7 @@ mod tests {
         const NUM_INSTRUCTIONS: usize = 7;
         let load_image =
             LoadImageImpl(b"\x55\x48\x89\xe5\x89\x7d\xfc\x8b\x45\xfc\x0f\xaf\xc0\x5d\xc3".to_vec());
-        let mut sleigh = Sleigh::new();
+        let mut sleigh = GhidraSleigh::new();
         let sleigh_spec = fs::read_to_string("../tests/data/x86-64.sla")
             .expect("Failed to read sleigh spec file");
 
@@ -571,7 +570,7 @@ mod tests {
         const NUM_INSTRUCTIONS: usize = 7;
         let load_image =
             LoadImageImpl(b"\x55\x48\x89\xe5\x89\x7d\xfc\x8b\x45\xfc\x01\xc0\x5d\xc3".to_vec());
-        let mut sleigh = Sleigh::new();
+        let mut sleigh = GhidraSleigh::new();
         let sleigh_spec = fs::read_to_string("../tests/data/x86-64.sla")
             .expect("Failed to read processor spec file");
         let processor_spec =
@@ -637,7 +636,7 @@ mod tests {
 
     #[test]
     pub fn register_from_name() {
-        let mut sleigh = Sleigh::new();
+        let mut sleigh = GhidraSleigh::new();
         let sleigh_spec = fs::read_to_string("../tests/data/x86-64.sla")
             .expect("Failed to read processor spec file");
         let processor_spec =

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -18,7 +18,7 @@ pub enum Error {
     MemoryAccess(#[from] crate::mem::Error),
 
     #[error("failed to decode instruction: {0}")]
-    InstructionDecoding(String),
+    InstructionDecoding(#[from] sla::Error),
 
     #[error("symbolic condition")]
     SymbolicCondition(SymbolicBit),

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2,7 +2,7 @@ use thiserror;
 
 use crate::emulator::{ControlFlow, Destination, PcodeEmulator};
 use crate::mem::{ExecutableMemory, SymbolicMemory, SymbolicMemoryReader, SymbolicMemoryWriter};
-use sla::{Address, AddressSpace, Disassembly, Slegh, Sleigh, VarnodeData};
+use sla::{Address, AddressSpace, Slegh, Sleigh, VarnodeData};
 use sym::{SymbolicBit, SymbolicBitVec, SymbolicByte};
 
 // TODO Emulator can also have memory access errors. Probably better to write a custom

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2,7 +2,7 @@ use thiserror;
 
 use crate::emulator::{ControlFlow, Destination, PcodeEmulator};
 use crate::mem::{ExecutableMemory, SymbolicMemory, SymbolicMemoryReader, SymbolicMemoryWriter};
-use sla::{Address, AddressSpace, Slegh, Sleigh, VarnodeData};
+use sla::{Address, AddressSpace, Sleigh, VarnodeData};
 use sym::{SymbolicBit, SymbolicBitVec, SymbolicByte};
 
 // TODO Emulator can also have memory access errors. Probably better to write a custom
@@ -38,14 +38,14 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub struct Processor<E: PcodeEmulator, M: SymbolicMemory> {
-    sleigh: Sleigh,
+pub struct Processor<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory> {
+    sleigh: S,
     emulator: E,
     memory: ExecutableMemory<M>,
 }
 
-impl<E: PcodeEmulator, M: SymbolicMemory> Processor<E, M> {
-    pub fn new(sleigh: Sleigh, emulator: E, memory: M) -> Self {
+impl<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory> Processor<S, E, M> {
+    pub fn new(sleigh: S, emulator: E, memory: M) -> Self {
         Processor {
             memory: ExecutableMemory(memory),
             emulator,
@@ -53,7 +53,7 @@ impl<E: PcodeEmulator, M: SymbolicMemory> Processor<E, M> {
         }
     }
 
-    pub fn sleigh(&self) -> &Sleigh {
+    pub fn sleigh(&self) -> &S {
         &self.sleigh
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fs};
 
-use sla::{OpCode, Sleigh};
+use sla::{GhidraSleigh, OpCode};
 use symbolic_pcode::emulator::{self, ControlFlow, PcodeEmulator, StandardPcodeEmulator};
 use symbolic_pcode::mem::SymbolicMemory;
 
@@ -42,8 +42,8 @@ impl TracingEmulator {
     }
 }
 
-pub fn x86_64_sleigh() -> Sleigh {
-    let mut sleigh = Sleigh::new();
+pub fn x86_64_sleigh() -> GhidraSleigh {
+    let mut sleigh = GhidraSleigh::new();
     let sleigh_spec =
         fs::read_to_string("tests/data/x86-64.sla").expect("failed to read processor spec file");
     let processor_spec =

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -3,8 +3,8 @@ mod common;
 use std::path::Path;
 
 use common::{x86_64_sleigh, TracingEmulator};
-use sla::{Address, VarnodeData};
-use sym::{self, SymbolicBit, SymbolicBitVec, SymbolicByte};
+use sla::{Address, Slegh, VarnodeData};
+use sym::{self, SymbolicBit, SymbolicByte};
 use symbolic_pcode::{
     emulator::{PcodeEmulator, StandardPcodeEmulator},
     mem::{Memory, SymbolicMemory, SymbolicMemoryWriter},

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -3,7 +3,7 @@ mod common;
 use std::path::Path;
 
 use common::{x86_64_sleigh, TracingEmulator};
-use sla::{Address, Slegh, VarnodeData};
+use sla::{Address, GhidraSleigh, Sleigh, VarnodeData};
 use sym::{self, SymbolicBit, SymbolicByte};
 use symbolic_pcode::{
     emulator::{PcodeEmulator, StandardPcodeEmulator},
@@ -14,7 +14,10 @@ use symbolic_pcode::{
 const INITIAL_STACK: u64 = 0x8000000000;
 const EXIT_RIP: u64 = 0xFEEDBEEF0BADF00D;
 
-fn processor_with_image(image: impl AsRef<Path>, entry: u64) -> Processor<TracingEmulator, Memory> {
+fn processor_with_image(
+    image: impl AsRef<Path>,
+    entry: u64,
+) -> Processor<GhidraSleigh, TracingEmulator, Memory> {
     let sleigh = x86_64_sleigh();
     let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
     let memory = Memory::new();
@@ -79,7 +82,9 @@ fn processor_with_image(image: impl AsRef<Path>, entry: u64) -> Processor<Tracin
     processor
 }
 
-fn init_registers<E: PcodeEmulator, M: SymbolicMemory>(processor: &mut Processor<E, M>) {
+fn init_registers<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory>(
+    processor: &mut Processor<S, E, M>,
+) {
     let mut bitvar = 0;
     let registers = ["RAX", "RBX", "RCX", "RDX", "RSI", "RDI"]
         .into_iter()


### PR DESCRIPTION
This update changes renamed `Sleigh` to `GhidraSleigh` and in favor of a trait named `Sleigh`. This trait will help improve unit testing for the processor API and also makes clear that the included implementation uses the sleigh code from Ghidra.

As a part of this change, some APIs were changed to improve the trait type signatures. This included a common `Disassembly` type for both pcode and native disassemblies (previously called `DecodeResponse`). Furthermore, the `String` errors were finally converted to a `thiserror::Error` enumeration.

Note some APIs which cross FFI boundaries still have `String` types for their errors. This is because they are ultimately serialized to their `Display`. Including them in the `Error` enum implies they could potentially be handled, but when we finally capture them on the Rust side, they would be a String. Moreover, it would be difficult to distinguish them from C++ exception errors (also captured as a `String`). So to avoid giving the impression they can be handled as a type, they are maintained as `String`.