### PR TITLE
Improvements to various APIs

### DIFF
--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -104,7 +104,7 @@ impl From<&sys::Address> for Address {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VarnodeData {
     pub address: Address,
     pub size: usize,
@@ -305,10 +305,10 @@ pub struct AssemblyInstruction {
 /// A disassembly of instructions originating from a [VarnodeData].
 pub struct Disassembly<T> {
     /// The disassembled instructions
-    instructions: Vec<T>,
+    pub instructions: Vec<T>,
 
     /// The origin of the instructions
-    origin: VarnodeData,
+    pub origin: VarnodeData,
 }
 
 impl<T> Disassembly<T> {
@@ -318,16 +318,6 @@ impl<T> Disassembly<T> {
             instructions,
             origin,
         }
-    }
-
-    /// Reference to the disassembled instructions
-    pub fn instructions(&self) -> impl AsRef<[T]> + '_ {
-        &self.instructions
-    }
-
-    /// Reference to the origin of the disassembled instructions
-    pub fn origin(&self) -> &VarnodeData {
-        &self.origin
     }
 }
 

--- a/sla/src/sleigh.rs
+++ b/sla/src/sleigh.rs
@@ -600,7 +600,7 @@ mod tests {
     }
 
     fn dump_pcode_response(response: &Disassembly<PcodeInstruction>) {
-        for instruction in response.instructions().as_ref() {
+        for instruction in &response.instructions {
             print!(
                 "{}:{:016x} | {:?}",
                 instruction.address.address_space.name,
@@ -654,7 +654,7 @@ mod tests {
                 .disassemble_pcode(&load_image, address)
                 .expect("Failed to decode instruction");
             dump_pcode_response(&response);
-            offset += response.origin().size as u64;
+            offset += response.origin.size as u64;
         }
         assert_eq!(offset, 15, "Expected 15 bytes to be decoded");
     }
@@ -724,7 +724,7 @@ mod tests {
                 "{}:{:016x} | {} {}",
                 expected[i].0, expected[i].1, expected[i].2, expected[i].3
             );
-            offset += response.origin().size as u64;
+            offset += response.origin.size as u64;
         }
     }
 

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -46,9 +46,6 @@ pub enum Error {
     #[error("no data defined at address {0}")]
     UndefinedData(Address),
 
-    #[error("address {0} has non-literal bit at index {1}")]
-    UnexpectedSymbolicData(Address, usize),
-
     #[error("arguments provided are not valid: {0}")]
     InvalidArguments(String),
 
@@ -334,26 +331,16 @@ impl SymbolicMemoryWriter for MemoryTree {
     }
 }
 
-pub struct ExecutableMemory<M: SymbolicMemory>(pub M);
+pub struct ExecutableMemory<'a, M: SymbolicMemory>(pub &'a M);
 
-impl<M: SymbolicMemory> SymbolicMemoryReader for ExecutableMemory<M> {
+impl<'a, M: SymbolicMemory> SymbolicMemoryReader for ExecutableMemory<'a, M> {
     fn read(&self, varnode: &VarnodeData) -> Result<Vec<SymbolicByte>> {
         self.0.read(varnode)
     }
 }
 
-impl<M: SymbolicMemory> SymbolicMemoryWriter for ExecutableMemory<M> {
-    fn write(
-        &mut self,
-        output: &VarnodeData,
-        data: impl IntoIterator<Item = impl Into<SymbolicByte>>,
-    ) -> Result<()> {
-        self.0.write(output, data)
-    }
-}
-
 /// Implementation of the LoadImage trait to enable loading instructions from memory
-impl<M: SymbolicMemory> sla::LoadImage for ExecutableMemory<M> {
+impl<'a, M: SymbolicMemory> sla::LoadImage for ExecutableMemory<'a, M> {
     fn instruction_bytes(&self, input: &VarnodeData) -> std::result::Result<Vec<u8>, String> {
         let bytes = self.read(&input);
 

--- a/sym/src/convert.rs
+++ b/sym/src/convert.rs
@@ -22,10 +22,7 @@ impl TryFrom<SymbolicBit> for bool {
         if let SymbolicBit::Literal(value) = value {
             Ok(value)
         } else {
-            Err(ConcretizationError::NonLiteralBit {
-                bit_index: 0,
-                byte_index: 0,
-            })
+            Err(ConcretizationError::NonLiteralBit { bit_index: 0 })
         }
     }
 }
@@ -296,8 +293,7 @@ where
             std::borrow::Cow::Borrowed(SymbolicBit::Literal(bit)) => *bit,
             _ => {
                 return Err(ConcretizationError::NonLiteralBit {
-                    bit_index,
-                    byte_index,
+                    bit_index: 8 * byte_index + bit_index,
                 })
             }
         };
@@ -444,10 +440,7 @@ mod tests {
         let err = bool::try_from(SymbolicBit::Variable(0)).unwrap_err();
         assert!(matches!(
             err,
-            ConcretizationError::NonLiteralBit {
-                byte_index: 0,
-                bit_index: 0,
-            }
+            ConcretizationError::NonLiteralBit { bit_index: 0 }
         ));
     }
 
@@ -522,19 +515,13 @@ mod tests {
         let err = concretize::<u8, 1>(array.iter()).unwrap_err();
         assert!(matches!(
             err,
-            ConcretizationError::NonLiteralBit {
-                byte_index: 0,
-                bit_index: 0
-            }
+            ConcretizationError::NonLiteralBit { bit_index: 0 }
         ));
 
         let err = concretize_into::<u8, 1>(array).unwrap_err();
         assert!(matches!(
             err,
-            ConcretizationError::NonLiteralBit {
-                byte_index: 0,
-                bit_index: 0
-            }
+            ConcretizationError::NonLiteralBit { bit_index: 0 }
         ));
     }
 

--- a/sym/src/sym.rs
+++ b/sym/src/sym.rs
@@ -29,8 +29,8 @@ pub enum SymbolicBit {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConcretizationError {
-    #[error("non-literal bit in byte {byte_index} at bit index {bit_index}")]
-    NonLiteralBit { byte_index: usize, bit_index: usize },
+    #[error("non-literal bit at index {bit_index}")]
+    NonLiteralBit { bit_index: usize },
 
     #[error("value exceeded maximum number of bytes ({max_bytes})")]
     Overflow { max_bytes: usize },


### PR DESCRIPTION
* `VarnodeData` can now be tested for equality
* `Disassembly` data is now directly accessible instead of hidden behind unnecessary accessors. The accessors created complications with data borrowing, such as returning a reference to a specific `PcodeInstruction`.
* `ConcretizationError` now records the symbolic bit directly instead of in a combination of bit and byte index.
* `emulator::Error::SymbolicAddress` now encodes the address as `SymbolicBitVec` instead of `Vec<SymbolicByte>`.
* `ControlFlow::ConditionalBranch` now includes the origin of the branch condition
* `mem::Error::UnexpectedSymbolicData` was removed since it is no longer used
* `mem::ExecutableMemory` was changed into a wrapper around a memory reference. By not transferring ownership, the `ExecutableMemory` can be constructed just prior to needing to load the instruction data. This better supports alternative memory models.