### PR TITLE
Add processor implementation

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -47,6 +47,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The pcode emulator structure that holds the necessary data for emulation.
+#[derive(Debug, Clone)]
 pub struct StandardPcodeEmulator {
     address_spaces_by_id: std::collections::BTreeMap<AddressSpaceId, AddressSpace>,
 }
@@ -176,6 +177,9 @@ impl PcodeEmulator for StandardPcodeEmulator {
 }
 
 impl StandardPcodeEmulator {
+    /// Create a new emulator over the given set of address spaces. These address spaces are
+    /// necessary to support indirect memory lookups, since such lookups are encoded into the
+    /// pcode operands as address space ids.
     pub fn new(address_spaces: impl IntoIterator<Item = AddressSpace>) -> Self {
         Self {
             address_spaces_by_id: address_spaces

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -197,14 +197,6 @@ impl PcodeExecution {
     }
 }
 
-pub trait ProcessorTrait {
-    type State;
-
-    fn memory(&self) -> &impl SymbolicMemory;
-    fn memory_mut(&mut self) -> &mut impl SymbolicMemory;
-    fn state(&self) -> &Self::State;
-}
-
 pub struct ProcessorManager<E: PcodeEmulator + Clone, H: ProcessorResponseHandler> {
     processors: Vec<Processor<E, H>>,
     sleigh: sla::GhidraSleigh,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,9 +1,11 @@
 use thiserror;
 
 use crate::emulator::{ControlFlow, Destination, PcodeEmulator};
-use crate::mem::{ExecutableMemory, SymbolicMemory};
-use sla::{Address, AddressSpace, Disassembly, PcodeInstruction, Sleigh, VarnodeData};
-use sym::{SymbolicBit, SymbolicBitVec, SymbolicByte};
+use crate::mem::{ExecutableMemory, Memory, MemoryBranch, SymbolicMemory};
+use sla::{
+    Address, AddressSpace, AssemblyInstruction, Disassembly, PcodeInstruction, Sleigh, VarnodeData,
+};
+use sym::SymbolicBit;
 
 // TODO Emulator can also have memory access errors. Probably better to write a custom
 // derivation that converts emulator errors into processor errors.
@@ -16,6 +18,10 @@ pub enum Error {
     /// Error occurred while accessing a memory location
     #[error(transparent)]
     MemoryAccess(#[from] crate::mem::Error),
+
+    /// Error occurred while accessing a memory location
+    #[error(transparent)]
+    SymbolicError(#[from] sym::ConcretizationError),
 
     #[error("failed to decode instruction: {0}")]
     InstructionDecoding(#[from] sla::Error),
@@ -38,182 +44,369 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub struct Processor<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory> {
-    sleigh: S,
-    emulator: E,
-    memory: M,
+#[derive(Clone, Debug)]
+pub struct PcodeExecution {
+    pcode: Disassembly<PcodeInstruction>,
+    index: usize,
 }
 
-impl<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory> Processor<S, E, M> {
-    pub fn new(sleigh: S, emulator: E, memory: M) -> Self {
-        Processor {
-            memory,
-            emulator,
-            sleigh,
+enum NextExecution {
+    NextInstruction,
+    Jump(Address),
+    PcodeOffset(i64),
+}
+
+enum BranchingNextExecution {
+    Branch(SymbolicBit, NextExecution, NextExecution),
+    Flow(NextExecution),
+}
+
+impl PcodeExecution {
+    pub fn new(pcode: Disassembly<PcodeInstruction>) -> Self {
+        Self { pcode, index: 0 }
+    }
+
+    pub fn origin(&self) -> &VarnodeData {
+        &self.pcode.origin
+    }
+
+    pub fn current_instruction(&self) -> &PcodeInstruction {
+        &self.pcode.instructions[self.index]
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pcode.instructions.is_empty()
+    }
+
+    pub fn is_final_instruction(&self) -> bool {
+        self.index + 1 == self.pcode.instructions.len()
+    }
+
+    pub fn update_index(&mut self, offset: i64) -> Result<()> {
+        // Index is always safe to convert to i64
+        let index = i64::try_from(self.index).unwrap() + offset;
+        let index = index.try_into().map_err(|err| {
+            Error::InvalidArgument(format!(
+                "Offset {offset} from index {index} is invalid: {err}"
+            ))
+        })?;
+
+        if index >= self.pcode.instructions.len() {
+            return Err(Error::InvalidArgument(format!(
+                "Offset {offset} from index {index} exceeds pcode instruction length {len}",
+                len = self.pcode.instructions.len(),
+                index = self.index
+            )));
+        }
+
+        self.index = index;
+        Ok(())
+    }
+
+    pub fn index_from_offset(&self, offset: i64) -> Result<usize> {
+        // Index is always safe to convert to i64
+        let index = i64::try_from(self.index).unwrap() + offset;
+        let index = index.try_into().map_err(|err| {
+            Error::InvalidArgument(format!(
+                "Offset {offset} from index {index} is invalid: {err}"
+            ))
+        })?;
+
+        if index < self.pcode.instructions.len() {
+            Ok(index)
+        } else {
+            Err(Error::InvalidArgument(format!(
+                "Offset {offset} from index {index} exceeds pcode instruction length {len}",
+                len = self.pcode.instructions.len(),
+                index = self.index
+            )))
         }
     }
 
-    pub fn sleigh(&self) -> &S {
+    pub fn offset(self, offset: i64) -> Result<Self> {
+        // Index is always safe to convert to i64
+        let index = i64::try_from(self.index).unwrap() + offset;
+        let index = index.try_into().map_err(|err| {
+            Error::InvalidArgument(format!(
+                "Offset {offset} from index {index} is invalid: {err}"
+            ))
+        })?;
+
+        if index < self.pcode.instructions.len() {
+            Ok(Self {
+                pcode: self.pcode,
+                index,
+            })
+        } else {
+            Err(Error::InvalidArgument(format!(
+                "Offset {offset} from index {index} exceeds pcode instruction length {len}",
+                len = self.pcode.instructions.len(),
+                index = self.index
+            )))
+        }
+    }
+
+    fn next_instruction(&self) -> Result<NextExecution> {
+        if self.is_final_instruction() {
+            Ok(NextExecution::NextInstruction)
+        } else {
+            Ok(NextExecution::PcodeOffset(1))
+        }
+    }
+
+    fn jump(&self, destination: &Destination) -> Result<NextExecution> {
+        match destination {
+            Destination::MachineAddress(address) => Ok(NextExecution::Jump(address.clone())),
+            Destination::PcodeAddress(offset) => Ok(NextExecution::PcodeOffset(*offset)),
+        }
+    }
+
+    fn branch(
+        &self,
+        condition: SymbolicBit,
+        destination: &Destination,
+    ) -> Result<BranchingNextExecution> {
+        Ok(BranchingNextExecution::Branch(
+            condition,
+            self.jump(destination)?,
+            self.next_instruction()?,
+        ))
+    }
+
+    fn next_execution(&self, flow: ControlFlow) -> Result<BranchingNextExecution> {
+        let result = match flow {
+            ControlFlow::NextInstruction
+            | ControlFlow::ConditionalBranch {
+                condition: sym::SymbolicBit::Literal(false),
+                ..
+            } => BranchingNextExecution::Flow(self.next_instruction()?),
+            ControlFlow::Jump(destination)
+            | ControlFlow::ConditionalBranch {
+                condition: sym::SymbolicBit::Literal(true),
+                destination,
+                ..
+            } => BranchingNextExecution::Flow(self.jump(&destination)?),
+            ControlFlow::ConditionalBranch {
+                destination,
+                condition,
+                ..
+            } => self.branch(condition, &destination)?,
+        };
+
+        Ok(result)
+    }
+}
+
+pub trait ProcessorTrait {
+    type State;
+
+    fn memory(&self) -> &impl SymbolicMemory;
+    fn memory_mut(&mut self) -> &mut impl SymbolicMemory;
+    fn state(&self) -> &Self::State;
+}
+
+pub struct ProcessorManager<E: PcodeEmulator + Clone, H: ProcessorResponseHandler> {
+    processors: Vec<Processor<E, H>>,
+    sleigh: sla::GhidraSleigh,
+}
+
+impl<E: PcodeEmulator + Clone, H: ProcessorResponseHandler> ProcessorManager<E, H> {
+    pub fn new(sleigh: sla::GhidraSleigh, processor: Processor<E, H>) -> Self {
+        Self {
+            sleigh,
+            processors: vec![processor],
+        }
+    }
+
+    pub fn sleigh(&self) -> &sla::GhidraSleigh {
         &self.sleigh
+    }
+
+    pub fn step_all(&mut self) -> Result<()> {
+        for i in 0..self.processors.len() {
+            if let Some(new_processor) = self.processors[i].step(&self.sleigh)? {
+                self.processors.push(new_processor);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.processors.is_empty()
+    }
+
+    pub fn remove_all(
+        &mut self,
+        filter: impl Fn(&Processor<E, H>) -> bool,
+    ) -> Vec<Processor<E, H>> {
+        let mut removed = Vec::new();
+        for i in (0..self.processors.len()).rev() {
+            if filter(&self.processors[i]) {
+                removed.push(self.processors.swap_remove(i));
+            }
+        }
+
+        removed
+    }
+
+    pub fn processors(&self) -> impl Iterator<Item = &Processor<E, H>> {
+        self.processors.iter()
+    }
+
+    pub fn processors_mut(&mut self) -> impl Iterator<Item = &mut Processor<E, H>> {
+        self.processors.iter_mut()
+    }
+}
+
+pub trait ProcessorResponseHandler: Clone {
+    fn fetched(&mut self, memory: &mut MemoryBranch) -> Result<Address>;
+    fn decoded(&mut self, memory: &mut MemoryBranch, execution: &PcodeExecution) -> Result<()>;
+    fn jumped(&mut self, memory: &mut MemoryBranch, address: &Address) -> Result<()>;
+}
+
+pub struct Processor<E: PcodeEmulator + Clone, H: ProcessorResponseHandler + Clone> {
+    memory: MemoryBranch,
+
+    // This state is mutable and can be transformed. This SomeThing object should mutate itself but
+    // never be replaced directly
+    state: ProcessorState,
+    handler: H,
+    emulator: E,
+}
+
+impl<E: PcodeEmulator + Clone, H: ProcessorResponseHandler> Processor<E, H> {
+    pub fn new(memory: Memory, emulator: E, handler: H) -> Self {
+        Self {
+            memory: MemoryBranch::new(memory),
+            emulator,
+            handler,
+            state: ProcessorState::Fetch,
+        }
+    }
+
+    pub fn memory(&self) -> &MemoryBranch {
+        &self.memory
+    }
+
+    pub fn memory_mut(&mut self) -> &mut MemoryBranch {
+        &mut self.memory
     }
 
     pub fn emulator(&self) -> &E {
         &self.emulator
     }
 
-    pub fn register(&self, name: impl AsRef<str>) -> Result<VarnodeData> {
-        let name = name.as_ref();
-        self.sleigh
-            .register_from_name(name)
-            .map_err(|err| Error::InvalidArgument(format!("invalid register {name}: {err}")))
+    pub fn state(&self) -> &ProcessorState {
+        &self.state
     }
 
-    pub fn address_space(&self, name: impl AsRef<str>) -> Result<AddressSpace> {
-        let name = name.as_ref();
-        self.sleigh
-            .address_spaces()
-            .into_iter()
-            .find(|addr_space| addr_space.name == name)
-            .ok_or_else(|| Error::InvalidArgument(format!("unknown address space: {name}")))
-    }
-
-    pub fn memory_mut(&mut self) -> &mut impl SymbolicMemory {
-        &mut self.memory
-    }
-
-    pub fn read_register(&self, name: impl AsRef<str>) -> Result<Vec<SymbolicByte>> {
-        let register = self.register(name)?;
-        let result = self.memory.read(&register)?;
-        Ok(result)
-    }
-
-    pub fn write_register(
-        &mut self,
-        name: impl AsRef<str>,
-        data: impl ExactSizeIterator<Item = impl Into<SymbolicByte>>,
-    ) -> Result<()> {
-        let register = self.register(name)?;
-        let result = self.memory.write(&register, data)?;
-        Ok(result)
-    }
-
-    pub fn write_address(
-        &mut self,
-        address: Address,
-        data: impl ExactSizeIterator<Item = impl Into<SymbolicByte>>,
-    ) -> Result<()> {
-        let varnode = VarnodeData {
-            address,
-            size: data.len(),
-        };
-        self.memory.write(&varnode, data)?;
-        Ok(())
-    }
-
-    pub fn default_code_space(&self) -> AddressSpace {
-        self.sleigh.default_code_space()
-    }
-
-    /// Emulates the current instruction in the instruction register. This assumes the instruction
-    /// in the register is an address offset into the [Sleigh::default_code_space].
-    ///
-    /// If the next instruction is an address into a different address space, the error variant
-    /// [Error::InvalidAddressSpace] is returned.
-    pub fn single_step(&mut self, instruction_register_name: impl AsRef<str>) -> Result<()> {
-        // TODO Better error here
-        let rip = self
-            .read_register(&instruction_register_name)?
-            .into_iter()
-            .collect::<SymbolicBitVec>()
-            .try_into()
-            .map_err(|_| Error::InternalError("symbolic instruction address".into()))?;
-
-        let next_instr = self.emulate(Address {
-            offset: rip,
-            address_space: self.sleigh.default_code_space(),
-        })?;
-
-        if self.sleigh.default_code_space() != next_instr.address_space {
-            return Err(Error::InvalidAddressSpace {
-                address: next_instr,
-                expected: self.sleigh.default_code_space(),
-            });
-        }
-
-        self.write_register(
-            instruction_register_name,
-            next_instr
-                .offset
-                .to_le_bytes()
-                .into_iter()
-                .map(SymbolicByte::from),
-        )?;
-
-        Ok(())
-    }
-
-    pub fn emulate(&mut self, address: Address) -> Result<Address> {
-        let memory = ExecutableMemory(&self.memory);
-        let pcode = self
-            .sleigh
-            .disassemble_pcode(&memory, address)
-            .map_err(|err| Error::InstructionDecoding(err))?;
-        let next_addr = pcode.origin.address.offset + pcode.origin.size as u64;
-        let mut instruction_index = 0;
-        let pcode_instructions = &pcode.instructions;
-        let max_index = i64::try_from(pcode_instructions.len()).expect("too many instructions");
-
-        while (0..max_index).contains(&instruction_index) {
-            // SAFETY: Index is already bound by size of array
-            let instruction = unsafe {
-                &pcode_instructions[usize::try_from(instruction_index).unwrap_unchecked()]
-            };
-
-            match self.emulator.emulate(&mut self.memory, &instruction)? {
-                ControlFlow::NextInstruction => {
-                    instruction_index += 1;
-                }
-                ControlFlow::Jump(destination) => match destination {
-                    Destination::MachineAddress(addr) => {
-                        return Ok(addr);
+    pub fn step(&mut self, sleigh: &impl Sleigh) -> Result<Option<Self>> {
+        match &mut self.state {
+            ProcessorState::Fetch => {
+                let fetched_instruction = self.handler.fetched(&mut self.memory)?;
+                self.state = ProcessorState::Decode(DecodeInstruction::new(fetched_instruction));
+            }
+            ProcessorState::Decode(d) => {
+                let execution = d.decode(sleigh, ExecutableMemory(&self.memory))?;
+                self.handler.decoded(&mut self.memory, &execution)?;
+                self.state = ProcessorState::Execute(execution);
+            }
+            ProcessorState::Execute(x) if x.is_empty() => {
+                // Some instructions are decoded as noops.
+                self.state = ProcessorState::Fetch;
+            }
+            ProcessorState::Execute(x) => {
+                let control_flow = self
+                    .emulator
+                    .emulate(&mut self.memory, x.current_instruction())?;
+                match x.next_execution(control_flow)? {
+                    BranchingNextExecution::Flow(e1) => self.update_execution(e1)?,
+                    BranchingNextExecution::Branch(condition, e1, e2) => {
+                        let mut branched_processor = self.branch(condition);
+                        self.update_execution(e1)?;
+                        branched_processor.update_execution(e2)?;
+                        return Ok(Some(branched_processor));
                     }
-                    Destination::PcodeAddress(offset) => {
-                        instruction_index += offset;
-                    }
-                },
-                ControlFlow::ConditionalBranch {
-                    condition: sym::SymbolicBit::Literal(true),
-                    destination,
-                    ..
-                } => match destination {
-                    Destination::MachineAddress(addr) => {
-                        assert_eq!(addr.address_space, self.sleigh.default_code_space());
-                        return Ok(addr);
-                    }
-                    Destination::PcodeAddress(offset) => {
-                        instruction_index += offset;
-                    }
-                },
-                ControlFlow::ConditionalBranch {
-                    condition: sym::SymbolicBit::Literal(false),
-                    ..
-                } => {
-                    instruction_index += 1;
-                }
-                ControlFlow::ConditionalBranch { condition, .. } => {
-                    // TODO: Is this condition OR its negation an assumed constraint?
-                    return Err(Error::SymbolicCondition(condition));
                 }
             }
         }
 
-        // TODO: This assumes that any instruction index outside the valid bounds means proceed to
-        // the next instruction. For branchless pcode instructions this is correct. However if
-        // there is a relative pcode branch that reaches out-of-bounds it is unclear what the
-        // correct behavior is.
-        Ok(Address {
-            offset: next_addr,
-            address_space: pcode.origin.address.address_space.clone(),
-        })
+        Ok(None)
+    }
+
+    fn update_execution(&mut self, next_execution: NextExecution) -> Result<()> {
+        if let ProcessorState::Execute(execution) = &mut self.state {
+            match next_execution {
+                NextExecution::Jump(address) => {
+                    self.handler.jumped(&mut self.memory, &address)?;
+                    self.state = ProcessorState::Fetch;
+                }
+                NextExecution::NextInstruction => self.state = ProcessorState::Fetch,
+                NextExecution::PcodeOffset(offset) => execution.update_index(offset)?,
+            }
+
+            Ok(())
+        } else {
+            Err(Error::InternalError(format!(
+                "cannot update execution, current state is {state:?}",
+                state = self.state
+            )))
+        }
+    }
+
+    fn branch(&mut self, condition: SymbolicBit) -> Self {
+        Processor {
+            memory: self.memory.new_branch(condition),
+            state: self.state.clone(),
+            handler: self.handler.clone(),
+            emulator: self.emulator.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ProcessorState {
+    Fetch,
+    Decode(DecodeInstruction),
+    Execute(PcodeExecution),
+}
+
+#[derive(Clone, Debug)]
+pub struct DecodeInstruction {
+    address: Address,
+}
+
+impl DecodeInstruction {
+    pub fn new(address: Address) -> Self {
+        Self { address }
+    }
+
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    pub fn decode(
+        &self,
+        sleigh: &impl Sleigh,
+        memory: ExecutableMemory<MemoryBranch>,
+    ) -> Result<PcodeExecution> {
+        let pcode = sleigh
+            .disassemble_pcode(&memory, self.address.clone())
+            .map_err(Error::InstructionDecoding)?;
+
+        Ok(PcodeExecution::new(pcode))
+    }
+
+    pub fn disassemble(
+        &self,
+        sleigh: &impl Sleigh,
+        memory: ExecutableMemory<MemoryBranch>,
+    ) -> Result<Disassembly<AssemblyInstruction>> {
+        let assembly = sleigh
+            .disassemble_native(&memory, self.address.clone())
+            .map_err(Error::InstructionDecoding)?;
+
+        Ok(assembly)
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,79 @@
 use std::{collections::BTreeMap, fs};
 
-use sla::{GhidraSleigh, OpCode};
+use sla::{Address, AddressSpace, GhidraSleigh, OpCode, Sleigh, VarnodeData};
+use sym::SymbolicByte;
 use symbolic_pcode::emulator::{self, ControlFlow, PcodeEmulator, StandardPcodeEmulator};
-use symbolic_pcode::mem::SymbolicMemory;
+use symbolic_pcode::mem::{
+    MemoryBranch, SymbolicMemory, SymbolicMemoryReader, SymbolicMemoryWriter,
+};
+use symbolic_pcode::processor::{self, PcodeExecution, ProcessorResponseHandler};
 
+#[derive(Debug, Clone)]
+pub struct ProcessorHandlerX86 {
+    rip: VarnodeData,
+    instruction_address_space: AddressSpace,
+}
+
+impl ProcessorHandlerX86 {
+    pub fn new(sleigh: &impl Sleigh) -> Self {
+        let rip = sleigh
+            .register_from_name("RIP")
+            .expect("failed to get RIP register");
+        let instruction_address_space = sleigh.default_code_space();
+        Self {
+            rip,
+            instruction_address_space,
+        }
+    }
+}
+
+impl ProcessorResponseHandler for ProcessorHandlerX86 {
+    fn fetched(&mut self, memory: &mut MemoryBranch) -> processor::Result<Address> {
+        let instruction = memory.read(&self.rip)?;
+        let offset: u64 = sym::concretize_into(instruction)?;
+        Ok(Address::new(self.instruction_address_space.clone(), offset))
+    }
+
+    fn decoded(
+        &mut self,
+        memory: &mut MemoryBranch,
+        execution: &PcodeExecution,
+    ) -> processor::Result<()> {
+        let rip_value: u64 = sym::concretize_into(memory.read(&self.rip)?)?;
+        let bytes_read = u64::try_from(execution.origin().size).map_err(|err| {
+            processor::Error::InternalError(format!(
+                "RIP value {rip_value:016x} failed to convert to u64: {err}",
+            ))
+        })?;
+        let rip_value = rip_value.checked_add(bytes_read).ok_or_else(|| {
+            processor::Error::InternalError(format!(
+                "RIP {rip_value:016x} + {len} overflowed",
+                len = execution.origin().size
+            ))
+        })?;
+
+        memory.write(
+            &self.rip,
+            rip_value.to_le_bytes().into_iter().map(SymbolicByte::from),
+        )?;
+
+        Ok(())
+    }
+
+    fn jumped(&mut self, memory: &mut MemoryBranch, address: &Address) -> processor::Result<()> {
+        memory.write(
+            &self.rip,
+            address
+                .offset
+                .to_le_bytes()
+                .into_iter()
+                .map(SymbolicByte::from),
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct TracingEmulator {
     inner: StandardPcodeEmulator,
     executed_instructions: std::cell::RefCell<BTreeMap<OpCode, usize>>,
@@ -19,7 +89,7 @@ impl PcodeEmulator for TracingEmulator {
         *self
             .executed_instructions
             .borrow_mut()
-            .entry(instruction.op_code.into())
+            .entry(instruction.op_code)
             .or_default() += 1;
         Ok(result)
     }

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -2,13 +2,13 @@ mod common;
 
 use std::path::Path;
 
-use common::{x86_64_sleigh, TracingEmulator};
-use sla::{Address, GhidraSleigh, Sleigh, VarnodeData};
-use sym::{self, SymbolicBit, SymbolicByte};
+use common::{x86_64_sleigh, ProcessorHandlerX86, TracingEmulator};
+use sla::{Address, Sleigh, VarnodeData};
+use sym::{self, SymbolicBit, SymbolicBitVec, SymbolicByte};
 use symbolic_pcode::{
-    emulator::{PcodeEmulator, StandardPcodeEmulator},
-    mem::{Memory, SymbolicMemory, SymbolicMemoryWriter},
-    processor::{self, Processor},
+    emulator::StandardPcodeEmulator,
+    mem::{Memory, MemoryTree, SymbolicMemoryReader, SymbolicMemoryWriter},
+    processor::{self, Processor, ProcessorManager, ProcessorState},
 };
 
 const INITIAL_STACK: u64 = 0x8000000000;
@@ -17,41 +17,34 @@ const EXIT_RIP: u64 = 0xFEEDBEEF0BADF00D;
 fn processor_with_image(
     image: impl AsRef<Path>,
     entry: u64,
-) -> Processor<GhidraSleigh, TracingEmulator, Memory> {
+) -> ProcessorManager<TracingEmulator, ProcessorHandlerX86> {
     let sleigh = x86_64_sleigh();
-    let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
-    let memory = Memory::new();
-    let mut processor = Processor::new(sleigh, TracingEmulator::new(emulator), memory);
-
-    //let mut processor = common::Processor::new();
+    let mut memory = Memory::new();
 
     // Write image into memory
     let data = std::fs::read(image).expect("failed to read image file");
     let data_location = VarnodeData {
         address: Address {
             offset: 0,
-            address_space: processor.default_code_space(),
+            address_space: sleigh.default_code_space(),
         },
         size: data.len(),
     };
-    processor
-        .memory_mut()
+
+    memory
         .write(&data_location, data.into_iter().map(SymbolicByte::from))
         .expect("failed to write image into memory");
 
     // Init RIP to entry
-    let rip = processor.register("RIP").expect("invalid register");
+
+    let rip = sleigh.register_from_name("RIP").expect("invalid register");
     let data = entry.to_le_bytes().into_iter().map(SymbolicByte::from);
-    processor
-        .memory_mut()
-        .write(&rip, data)
-        .expect("failed to initialize RIP");
+    memory.write(&rip, data).expect("failed to initialize RIP");
 
     // Init RBP to magic EXIT_RIP value
-    let rbp = processor.register("RBP").expect("invalid register");
+    let rbp = sleigh.register_from_name("RBP").expect("invalid register");
     let data = EXIT_RIP.to_le_bytes().into_iter().map(SymbolicByte::from);
-    processor
-        .memory_mut()
+    memory
         .write(&rbp, data.clone())
         .expect("failed to initialize RBP");
 
@@ -59,32 +52,36 @@ fn processor_with_image(
     let stack_addr = VarnodeData {
         address: Address {
             offset: INITIAL_STACK,
-            address_space: processor.address_space("ram").expect("failed to find ram"),
+            address_space: sleigh
+                .address_space_by_name("ram")
+                .expect("failed to find ram"),
         },
         size: data.len(),
     };
-    processor
-        .memory_mut()
+    memory
         .write(&stack_addr, data)
         .expect("failed to initialize stack");
 
     // Init RSP to stack address
-    let rsp = processor.register("RSP").expect("invalid register");
+    let rsp = sleigh.register_from_name("RSP").expect("invalid register");
     let data = INITIAL_STACK
         .to_le_bytes()
         .into_iter()
         .map(SymbolicByte::from);
-    processor
-        .memory_mut()
-        .write(&rsp, data)
-        .expect("failed to initialize RSP");
+    memory.write(&rsp, data).expect("failed to initialize RSP");
 
-    processor
+    init_registers(&sleigh, &mut memory);
+
+    let handler = ProcessorHandlerX86::new(&sleigh);
+    let processor = Processor::new(
+        memory,
+        TracingEmulator::new(StandardPcodeEmulator::new(sleigh.address_spaces())),
+        handler,
+    );
+    ProcessorManager::new(sleigh, processor)
 }
 
-fn init_registers<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory>(
-    processor: &mut Processor<S, E, M>,
-) {
+fn init_registers(sleigh: &impl Sleigh, memory: &mut impl SymbolicMemoryWriter) {
     let mut bitvar = 0;
     let registers = ["RAX", "RBX", "RCX", "RDX", "RSI", "RDI"]
         .into_iter()
@@ -92,7 +89,7 @@ fn init_registers<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory>(
         .chain((8..16).map(|n| format!("R{n}")))
         .collect::<Vec<_>>();
 
-    for register in registers {
+    for register_name in registers {
         let mut bytes = Vec::with_capacity(8);
         for _ in 0..8 {
             let byte: SymbolicByte = [
@@ -110,9 +107,12 @@ fn init_registers<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory>(
             bitvar += 8;
         }
 
-        processor
-            .write_register(register, bytes.into_iter())
-            .expect("failed to write data");
+        let register = sleigh
+            .register_from_name(&register_name)
+            .unwrap_or_else(|err| panic!("invalid register {register_name}: {err}"));
+        memory
+            .write(&register, bytes.into_iter())
+            .unwrap_or_else(|err| panic!("failed to write register {register_name}: {err}"));
     }
 }
 
@@ -120,127 +120,105 @@ fn init_registers<S: Sleigh, E: PcodeEmulator, M: SymbolicMemory>(
 #[test]
 fn x86_64_registers() {
     let sleigh = x86_64_sleigh();
-    let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
-    let memory = Memory::new();
-    let mut processor = Processor::new(sleigh, emulator, memory);
 
+    let write_register = |memory: &mut Memory, name: &str, data: &[u8]| {
+        let register = sleigh
+            .register_from_name(name)
+            .expect(&format!("invalid register {name}"));
+        memory
+            .write(&register, data.into_iter().cloned())
+            .expect(&format!("failed to write register {name}"));
+    };
+
+    let read_register = |memory: &Memory, name: &str| {
+        let register = sleigh
+            .register_from_name(name)
+            .expect(&format!("invalid register {name}"));
+        memory
+            .read(&register)
+            .expect(&format!("failed to read register {name}"))
+    };
+
+    let mut memory = Memory::new();
     let registers = vec!['A', 'B', 'C', 'D'];
     for register in registers {
-        processor
-            .write_register(
-                format!("R{register}X"),
-                vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].into_iter(),
-            )
-            .expect("failed to write register");
-        let rax: u64 = sym::concretize_into(
-            processor
-                .read_register(format!("R{register}X"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u64");
+        let name = format!("R{register}X");
+        let data = vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        write_register(&mut memory, &name, &data);
+
+        let rax: u64 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u64");
         assert_eq!(rax, 0x8877665544332211);
-        let eax: u32 = sym::concretize_into(
-            processor
-                .read_register(format!("E{register}X"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u32");
+
+        let name = format!("E{register}X");
+        let eax: u32 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u32");
         assert_eq!(eax, 0x44332211);
-        let ax: u16 = sym::concretize_into(
-            processor
-                .read_register(format!("{register}X"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u16");
+
+        let name = format!("{register}X");
+        let ax: u16 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u16");
         assert_eq!(ax, 0x2211);
-        let ah: u8 = sym::concretize_into(
-            processor
-                .read_register(format!("{register}H"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u8");
+
+        let name = format!("{register}H");
+        let ah: u8 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u8");
         assert_eq!(ah, 0x22);
-        let al: u8 = sym::concretize_into(
-            processor
-                .read_register(format!("{register}L"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u8");
+
+        let name = format!("{register}L");
+        let al: u8 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u8");
         assert_eq!(al, 0x11);
     }
 
     let registers = vec!["SI", "DI", "BP", "SP"];
     for register in registers {
-        processor
-            .write_register(
-                format!("R{register}"),
-                vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].into_iter(),
-            )
-            .expect("failed to write register");
-        let r: u64 = sym::concretize_into(
-            processor
-                .read_register(format!("R{register}"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u64");
+        let name = format!("R{register}");
+        let data = vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        write_register(&mut memory, &name, &data);
+
+        let r: u64 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u64");
         assert_eq!(r, 0x8877665544332211);
-        let e: u32 = sym::concretize_into(
-            processor
-                .read_register(format!("E{register}"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u32");
+
+        let name = format!("E{register}");
+        let e: u32 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u32");
         assert_eq!(e, 0x44332211);
-        let b: u16 = sym::concretize_into(
-            processor
-                .read_register(format!("{register}"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u16");
+
+        let name = format!("{register}");
+        let b: u16 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u16");
         assert_eq!(b, 0x2211);
-        let l: u8 = sym::concretize_into(
-            processor
-                .read_register(format!("{register}L"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u8");
+
+        let name = format!("{register}L");
+        let l: u8 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u8");
         assert_eq!(l, 0x11);
     }
 
     for register in 8..=15 {
-        processor
-            .write_register(
-                format!("R{register}"),
-                vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88].into_iter(),
-            )
-            .expect("failed to write register");
-        let r: u64 = sym::concretize_into(
-            processor
-                .read_register(format!("R{register}"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u64");
+        let name = format!("R{register}");
+        let data = vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        write_register(&mut memory, &name, &data);
+
+        let r: u64 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u64");
         assert_eq!(r, 0x8877665544332211);
-        let rd: u32 = sym::concretize_into(
-            processor
-                .read_register(format!("R{register}D"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u32");
+
+        let name = format!("R{register}D");
+        let rd: u32 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u32");
         assert_eq!(rd, 0x44332211);
-        let rw: u16 = sym::concretize_into(
-            processor
-                .read_register(format!("R{register}W"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u16");
+
+        let name = format!("R{register}W");
+        let rw: u16 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u16");
         assert_eq!(rw, 0x2211);
-        let rb: u8 = sym::concretize_into(
-            processor
-                .read_register(format!("R{register}B"))
-                .expect("failed to read register"),
-        )
-        .expect("failed to convert to u8");
+
+        let name = format!("R{register}B");
+        let rb: u8 =
+            sym::concretize_into(read_register(&memory, &name)).expect("failed to convert to u8");
         assert_eq!(rb, 0x11);
     }
 }
@@ -255,57 +233,78 @@ fn x86_64_registers() {
 /// ram:000000000000000c | POP RBP
 /// ram:000000000000000d | RET
 #[test]
-fn doubler_32b() -> Result<(), processor::Error> {
+fn doubler_32b() -> processor::Result<()> {
     let sleigh = x86_64_sleigh();
     let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
-    let memory = Memory::new();
-    let mut processor = Processor::new(sleigh, emulator, memory);
+    let mut memory = Memory::new();
     let base_addr = 0x84210000;
     let num_instructions = 7;
 
-    let code_space = processor.default_code_space();
-    processor.memory_mut().write_address(
+    let write_register = |memory: &mut Memory, name: &str, data: &[u8]| {
+        let register = sleigh
+            .register_from_name(name)
+            .unwrap_or_else(|err| panic!("invalid register {name}: {err}"));
+        memory
+            .write(&register, data.iter().copied())
+            .unwrap_or_else(|err| panic!("failed to write register {name}: {err}"));
+    };
+
+    let code_space = sleigh.default_code_space();
+    memory.write_address(
         Address::new(code_space, base_addr),
         b"\x55\x48\x89\xe5\x89\x7d\xfc\x8b\x45\xfc\x01\xc0\x5d\xc3\x00\x00"
-            .into_iter()
+            .iter()
             .copied(),
     )?;
 
-    processor.write_register(
-        "RSP",
-        b"\x00\x01\x01\x01\x01\x01\x01\x00".into_iter().copied(),
-    )?;
+    write_register(&mut memory, "RSP", b"\x00\x01\x01\x01\x01\x01\x01\x00");
+    write_register(&mut memory, "RBP", b"\x00\x02\x02\x02\x02\x02\x02\x00");
 
-    processor.write_register(
-        "RSP",
-        vec![0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00].into_iter(),
-    )?;
-
-    processor.write_register(
-        "RBP",
-        vec![0x00, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x00].into_iter(),
-    )?;
-
-    processor.write_address(
-        Address::new(processor.address_space("ram")?, 0x0001010101010100),
+    memory.write_address(
+        Address::new(
+            sleigh
+                .address_space_by_name("ram")
+                .expect("failed to find ram"),
+            0x0001010101010100,
+        ),
         vec![0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66].into_iter(),
     )?;
 
     let initial_value: u32 = 0x99;
-    processor.write_register("EDI", initial_value.to_le_bytes().into_iter())?;
-    processor.write_register("RIP", base_addr.to_le_bytes().into_iter())?;
+    write_register(&mut memory, "EDI", &initial_value.to_le_bytes());
+    write_register(&mut memory, "RIP", &base_addr.to_le_bytes());
+
+    let handler = ProcessorHandlerX86::new(&sleigh);
+    let mut processor = Processor::new(memory, emulator, handler);
+
     for _ in 0..num_instructions {
-        processor.single_step("RIP")?;
+        loop {
+            let step_response = processor.step(&sleigh)?;
+            if step_response.is_some() {
+                panic!("Unexpected branch: {state:?}", state = processor.state());
+            }
+
+            if matches!(processor.state(), processor::ProcessorState::Fetch) {
+                break;
+            }
+        }
     }
 
-    let rip: u64 = sym::concretize_into(processor.read_register("RIP")?)
+    let rip = sleigh
+        .register_from_name("RIP")
+        .expect("failed to get RIP register");
+    let rip_value: u64 = sym::concretize_into(processor.memory().read(&rip)?)
         .expect("failed to convert rip value to u64");
-    assert_eq!(rip, 0x66778899aabbccdd, "return address on stack");
+    assert_eq!(rip_value, 0x66778899aabbccdd, "return address on stack");
 
-    let rax: u64 = sym::concretize_into(processor.read_register("RAX")?)
+    let rax = sleigh
+        .register_from_name("RAX")
+        .expect("failed to get RAX register");
+    let rax_value: u64 = sym::concretize_into(processor.memory().read(&rax)?)
         .expect("failed to convert rax value to u64");
     assert_eq!(
-        u32::try_from(rax).expect("failed to convert rax to u32"),
+        u32::try_from(rax_value)
+            .unwrap_or_else(|err| panic!("failed to convert rax to u32: {rax_value:016x}: {err}")),
         2 * initial_value,
         "result should be double initial value: {initial_value}",
     );
@@ -324,23 +323,42 @@ fn doubler_32b() -> Result<(), processor::Error> {
 #[test]
 fn pcode_coverage() -> processor::Result<()> {
     // Use address of the main function for the entry point
-    let mut processor = processor_with_image("tests/data/coverage/coverage", 0x1675);
-    init_registers(&mut processor);
+    let mut manager = processor_with_image("tests/data/coverage/coverage", 0x1675);
 
+    let rip = manager
+        .sleigh()
+        .register_from_name("RIP")
+        .expect("failed to get RIP register");
     loop {
-        processor.single_step("RIP")?;
+        manager.step_all()?;
 
         // Check if RIP is the magic value
-        let rip: u64 = sym::concretize_into(processor.read_register("RIP")?)
-            .expect("failed to convert RIP to u64");
-        if rip == EXIT_RIP {
+        let processors: Vec<_> = manager.processors().collect();
+        if processors.len() != 1 {
+            panic!(
+                "Unexpected number of processors: {len}",
+                len = processors.len()
+            );
+        }
+
+        let processor = processors[0];
+        let instruction_pointer: u64 = sym::concretize_into(processor.memory().read(&rip)?)?;
+
+        if instruction_pointer == EXIT_RIP && matches!(processor.state(), ProcessorState::Fetch) {
             break;
         }
     }
 
-    let rax: u64 = sym::concretize_into(processor.read_register("RAX")?)
-        .expect("failed to convert RAX to u64");
-    assert_eq!(rax, 0);
+    let processor = manager.processors().next().expect("no processors");
+    let rax = manager
+        .sleigh()
+        .register_from_name("RAX")
+        .expect("failed to get RAX register");
+    let return_value: u64 = sym::concretize_into(processor.memory().read(&rax)?)?;
+    assert_eq!(
+        return_value, 0,
+        "unexpected return value: {return_value:016x}"
+    );
 
     processor
         .emulator()
@@ -362,5 +380,109 @@ fn pcode_coverage() -> processor::Result<()> {
             .count(),
         38
     );
+    Ok(())
+}
+
+#[test]
+fn memory_tree() -> processor::Result<()> {
+    let sleigh = x86_64_sleigh();
+    let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
+    let mut memory = Memory::new();
+    let write_register = |memory: &mut Memory, name: &str, data: &[u8]| {
+        let register = sleigh
+            .register_from_name(name)
+            .expect(&format!("invalid register {name}"));
+        memory
+            .write(&register, data.into_iter().cloned())
+            .expect(&format!("failed to write register {name}"));
+    };
+
+    // Small program: if x > 0 { x + x } else { x * x }
+    // The input x is provided in the register EDI and is signed 32-bit
+    let program_bytes: Vec<u8> = vec![
+        0x55, // PUSH RBP
+        0x48, 0x89, 0xe5, // MOV RBP, RSP
+        0x89, 0x7d, 0xfc, // MOV DWORD PTR [RBP - 4], EDI
+        0x83, 0x7d, 0xfc, 0x00, // CMP DWORD PTR [RBP - 4], 0
+        0x7e, 0x07, // JLE [START + 0x14]
+        0x8b, 0x45, 0xfc, // MOV EAX, DWORD PTR [RBP - 0x4]
+        0x01, 0xc0, // ADD EAX, EAX
+        0xeb, 0x06, // JMP [START + 0x1a]
+        0x8b, 0x45, 0xfc, // MOV EAX, DWORD PTR [RBP - 0x4]
+        0x0f, 0xaf, 0xc0, // IMUL EAX, EAX
+        0x5d, // POP RBP
+        0xc3, // RET
+    ];
+
+    let code_offset = 0;
+    memory.write_address(
+        Address::new(sleigh.default_code_space(), code_offset),
+        program_bytes.into_iter(),
+    )?;
+    write_register(&mut memory, "RIP", &code_offset.to_le_bytes());
+
+    // Initialize stack and base pointer registers
+    write_register(&mut memory, "RSP", &INITIAL_STACK.to_le_bytes());
+    write_register(&mut memory, "RBP", &INITIAL_STACK.to_le_bytes());
+
+    // Put EXIT_RIP onto the stack. The final RET will trigger this.
+    memory.write_address(
+        Address::new(
+            sleigh
+                .address_space_by_name("ram")
+                .expect("failed to find ram"),
+            INITIAL_STACK,
+        ),
+        EXIT_RIP.to_le_bytes().into_iter(),
+    )?;
+
+    // Set input to concrete value
+    // TODO: Have a way to set this symbolically and then evaluate it with different values
+    let input_value = -sym::SymbolicBitVec::constant(3, 32);
+
+    let name = "EDI";
+    let register = sleigh
+        .register_from_name(name)
+        .unwrap_or_else(|err| panic!("invalid register {name}: {err}"));
+    memory
+        .write(&register, input_value.into_bytes())
+        .unwrap_or_else(|err| panic!("failed to write register {name}: {err}"));
+    let rip = sleigh
+        .register_from_name("RIP")
+        .expect("failed to find RIP");
+
+    let handler = ProcessorHandlerX86::new(&sleigh);
+    let processor = Processor::new(memory, emulator, handler);
+    let mut manager = ProcessorManager::new(sleigh, processor);
+
+    let mut finished = Vec::new();
+    loop {
+        finished.append(&mut manager.remove_all(|p| {
+            let rip_value: u64 =
+                sym::concretize_into(p.memory().read(&rip).expect("failed to read RIP"))
+                    .expect("failed to concretize RIP");
+            rip_value == EXIT_RIP
+        }));
+
+        if manager.is_empty() {
+            break;
+        }
+
+        manager.step_all()?;
+    }
+
+    // Output register is EAX
+    let eax = manager
+        .sleigh()
+        .register_from_name("EAX")
+        .unwrap_or_else(|err| panic!("failed to find EAX: {err}"));
+
+    let memory_tree = MemoryTree::new(finished.iter().map(|p| p.memory()), std::iter::empty());
+    let result = memory_tree.read(&eax)?;
+    let result: SymbolicBitVec = result.into_iter().collect();
+
+    let assertion = result.equals(SymbolicBitVec::constant(9, 32));
+    assert_eq!(assertion, sym::TRUE);
+
     Ok(())
 }

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -384,7 +384,7 @@ fn pcode_coverage() -> processor::Result<()> {
 }
 
 #[test]
-fn memory_tree() -> processor::Result<()> {
+fn conditional_branching() -> processor::Result<()> {
     let sleigh = x86_64_sleigh();
     let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
     let mut memory = Memory::new();


### PR DESCRIPTION
This change replaces the existing `Processor` implementation with a new one capable of exploring different state spaces due to branches with symbolic conditions. The `ProcessorManager` is used to manage this exploration, and is also capable of pruning processors to avoid further exploring their paths if desired.

This change renames `MemoryTree` to `MemoryBranch` and adds a `MemoryTree` view on a collection of branches. The new `MemoryTree` can be used to read a value simultaneously from all branches, conditioned in their respective branch predicates.

The x86-64 integration tests have all been updated to use the new `Processor`, and a new test has been added to demonstrate how the `ProcessorManager` can be used to explore branching paths.