### PR TITLE
Add z3 integration test, improvements to Aiger module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.5"
+z3 = "0.12"
 
 [[bench]]
 name = "emulator"

--- a/sym/src/lib.rs
+++ b/sym/src/lib.rs
@@ -1,4 +1,4 @@
-mod aiger;
+pub mod aiger;
 mod buf;
 mod convert;
 mod sym;

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -483,8 +483,6 @@ fn z3_integration() -> processor::Result<()> {
     let result: SymbolicBitVec = result.into_iter().collect();
 
     let assertion = result.equals(SymbolicBitVec::constant(8, 32));
-    // assert_eq!(assertion, sym::TRUE);
-
     let aiger = sym::aiger::Aiger::from_bits(std::iter::once(assertion));
     let cfg = z3::Config::new();
     let ctx = z3::Context::new(&cfg);


### PR DESCRIPTION
Added an integration test with `z3` solver. This test necessarily exercised integration with the Aiger module that revealed opportunities for enhancements. 

1. The indexes for `And` gates were created in such a way that it made it difficult to recreate them as constraints for the solver. This has been updated to ensure a gate's index is always greater than both its LHS and RHS.
2. `And` gate would always attempt to index its LHS and RHS components even if it had already been indexed. This didn't result in incorrect indexing, but the duplicated effort wasted a lot of time for large circuits.