### PR TITLE
Performance improvements to several SymbolicBitVec APIs

### DIFF
--- a/sym/src/sym.rs
+++ b/sym/src/sym.rs
@@ -1,7 +1,6 @@
+use std::collections::VecDeque;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-
-use thiserror;
 
 use crate::buf::SymbolicByte;
 
@@ -63,7 +62,7 @@ impl std::ops::Not for SymbolicBit {
             // TODO: Use Rc::unwrap_or_clone(y) once feature is stable
             // See https://github.com/rust-lang/rust/issues/93610
             SymbolicBit::Not(y) => (*y).clone(),
-            _ => return SymbolicBit::Not(Rc::new(self)),
+            _ => SymbolicBit::Not(Rc::new(self)),
         }
     }
 }
@@ -118,7 +117,7 @@ impl std::ops::BitXor for SymbolicBit {
 
 #[derive(Debug, Clone)]
 pub struct SymbolicBitVec {
-    pub(crate) bits: Vec<SymbolicBit>,
+    bits: VecDeque<SymbolicBit>,
 }
 
 impl TryInto<Vec<SymbolicByte>> for SymbolicBitVec {
@@ -138,20 +137,52 @@ impl TryInto<Vec<SymbolicByte>> for SymbolicBitVec {
 
 impl IntoIterator for SymbolicBitVec {
     type Item = SymbolicBit;
-    type IntoIter = std::vec::IntoIter<SymbolicBit>;
+    type IntoIter = std::collections::vec_deque::IntoIter<SymbolicBit>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.bits.into_iter()
     }
 }
 
+impl std::ops::Index<usize> for SymbolicBitVec {
+    type Output = SymbolicBit;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.bits[index]
+    }
+}
+
+impl FromIterator<SymbolicBit> for SymbolicBitVec {
+    fn from_iter<T: IntoIterator<Item = SymbolicBit>>(iter: T) -> Self {
+        Self {
+            bits: iter.into_iter().collect(),
+        }
+    }
+}
+
 static START_SYMBOL: AtomicUsize = AtomicUsize::new(0);
 impl SymbolicBitVec {
+    pub fn msb(&self) -> Option<&SymbolicBit> {
+        self.bits.back()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bits.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.bits.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &SymbolicBit> {
+        self.bits.iter()
+    }
+
     pub fn with_size(num_bits: usize) -> Self {
         let start_symbol = START_SYMBOL.fetch_add(num_bits, Ordering::SeqCst);
-        let mut bits = Vec::with_capacity(num_bits);
+        let mut bits = VecDeque::with_capacity(num_bits);
         for i in 0..num_bits {
-            bits.push(SymbolicBit::Variable(start_symbol + i));
+            bits.push_back(SymbolicBit::Variable(start_symbol + i));
         }
 
         Self { bits }
@@ -191,14 +222,14 @@ impl SymbolicBitVec {
 
     pub fn empty() -> Self {
         Self {
-            bits: Vec::with_capacity(0),
+            bits: VecDeque::with_capacity(0),
         }
     }
 
     pub fn constant(mut value: usize, num_bits: usize) -> Self {
-        let mut bits = Vec::with_capacity(num_bits);
+        let mut bits = VecDeque::with_capacity(num_bits);
         for _ in 0..num_bits {
-            bits.push(SymbolicBit::Literal(value & 0x1 > 0));
+            bits.push_back(SymbolicBit::Literal(value & 0x1 > 0));
             value >>= 1;
         }
 
@@ -242,10 +273,10 @@ impl SymbolicBitVec {
         if self.bits.len() == 1 {
             // SAFETY: Know both self and rhs bits length is 1
             unsafe {
-                self.bits
-                    .pop()
+                self.msb()
+                    .cloned()
                     .unwrap_unchecked()
-                    .equals(rhs.bits.pop().unwrap_unchecked())
+                    .equals(rhs.msb().cloned().unwrap_unchecked())
             }
         } else {
             let partition = self.bits.len() / 2;
@@ -258,7 +289,7 @@ impl SymbolicBitVec {
     /// Concatenates the left-hand side with the right-hand side, creating a new `SymbolicBitVec`
     /// with a combined length of both inputs.
     pub fn concat(mut self, mut rhs: Self) -> Self {
-        let mut bits = Vec::with_capacity(self.bits.len() + rhs.bits.len());
+        let mut bits = VecDeque::with_capacity(self.bits.len() + rhs.bits.len());
         bits.append(&mut self.bits);
         bits.append(&mut rhs.bits);
         Self { bits }
@@ -292,10 +323,10 @@ impl SymbolicBitVec {
     /// Create a new `SymbolicBitVec` with the number of additional bits specified as the
     /// most-significant bits. The additional bits are clones of the original most significant-bit.
     pub fn sign_extend(self, num_bits: usize) -> Self {
-        let mut extension = Vec::with_capacity(num_bits);
-        let msb = &self.bits[self.bits.len() - 1];
+        let mut extension = VecDeque::with_capacity(num_bits);
+        let msb = self.msb().unwrap();
         for _ in 0..num_bits {
-            extension.push(msb.clone());
+            extension.push_back(msb.clone());
         }
 
         let extension = Self { bits: extension };
@@ -304,7 +335,7 @@ impl SymbolicBitVec {
 
     pub fn addition_with_carry(self, rhs: Self) -> (Self, SymbolicBit) {
         let mut carry = self.clone().addition_carry_bits(rhs.clone());
-        let overflow = carry.bits.pop().unwrap();
+        let overflow = carry.bits.pop_back().unwrap();
         let sum = self ^ rhs ^ carry;
         (sum, overflow)
     }
@@ -313,14 +344,14 @@ impl SymbolicBitVec {
         let diff = self.clone() - rhs.clone();
 
         // Positive overflow occurs if sign bits are (0, 1) but 1 in sum
-        let positive_overflow = !self.bits.last().cloned().unwrap()
-            & rhs.bits.last().cloned().unwrap()
-            & diff.bits.last().cloned().unwrap();
+        let positive_overflow = !self.msb().cloned().unwrap()
+            & rhs.msb().cloned().unwrap()
+            & diff.msb().cloned().unwrap();
 
         // Negative overflow occurs if sign bits are (1, 0) but 0 in sum
-        let negative_overflow = self.bits.last().cloned().unwrap()
-            & !rhs.bits.last().cloned().unwrap()
-            & !diff.bits.last().cloned().unwrap();
+        let negative_overflow = self.msb().cloned().unwrap()
+            & !rhs.msb().cloned().unwrap()
+            & !diff.msb().cloned().unwrap();
 
         // Overflow occurs if either positive or negative overflow occurs
         (diff, positive_overflow | negative_overflow)
@@ -397,8 +428,10 @@ impl SymbolicBitVec {
 
                 // TODO All of the bits placed into x will be overwritten. It could improve
                 // performance if these bits were extracted instead of cloned.
-                let x: Self = product.bits[rhs_size..rhs_size + num_sum_bits]
+                let x: Self = product
                     .iter()
+                    .skip(rhs_size)
+                    .take(num_sum_bits)
                     .cloned()
                     .collect();
                 let y = self
@@ -418,13 +451,13 @@ impl SymbolicBitVec {
 
             // Remove the current least significant bit corresponding to the RHS and shift
             // everything down.
-            product.bits.remove(0);
+            product.bits.pop_front();
 
             // The carry bit should only be added if the next iteration would not result in a
             // truncated addition. This is to ensure the number of product bits at the conclusion
             // of this loop contains the expected number of output bits.
             if max_sum_bits > self.len() {
-                product.bits.push(carry.unwrap());
+                product.bits.push_back(carry.unwrap());
             }
         }
 
@@ -454,7 +487,6 @@ impl SymbolicBitVec {
         let mut remainder = SymbolicBitVec::constant(0, dividend.len());
 
         for next_bit in dividend.bits.into_iter().rev() {
-            // TODO If we had a VecDeque then this would be constant time instead of O(n)
             remainder.bits.rotate_right(1);
             remainder.bits[0] = next_bit;
 
@@ -463,7 +495,6 @@ impl SymbolicBitVec {
             let diff = remainder.clone() - divisor.clone();
             remainder = remainder.mux(diff, selector.clone());
 
-            // TODO If we had a VecDeque then this would be constant time instead of O(n)
             quotient.bits.rotate_right(1);
             quotient.bits[0] = !selector;
         }
@@ -472,8 +503,8 @@ impl SymbolicBitVec {
     }
 
     pub fn signed_divide(self, dividend: Self) -> (Self, Self) {
-        let divisor_msb = self.bits.last().cloned().unwrap();
-        let dividend_msb = dividend.bits.last().cloned().unwrap();
+        let divisor_msb = self.msb().cloned().unwrap();
+        let dividend_msb = dividend.msb().cloned().unwrap();
 
         let unsigned_divisor = self.clone().mux(-self, !divisor_msb.clone());
         let unsigned_dividend = dividend.clone().mux(-dividend, !dividend_msb.clone());
@@ -491,11 +522,11 @@ impl SymbolicBitVec {
 
     pub fn addition_carry_bits(self, rhs: Self) -> Self {
         assert_eq!(self.bits.len(), rhs.bits.len());
-        let mut carry = Vec::with_capacity(self.bits.len() + 1);
-        carry.push(SymbolicBit::Literal(false));
-        carry.push(self[0].clone() & rhs[0].clone());
+        let mut carry = VecDeque::with_capacity(self.bits.len() + 1);
+        carry.push_back(SymbolicBit::Literal(false));
+        carry.push_back(self[0].clone() & rhs[0].clone());
         for i in 1..self.bits.len() {
-            carry.push(
+            carry.push_back(
                 (self[i].clone() & rhs[i].clone())
                     | (self[i].clone() & carry[i].clone())
                     | (rhs[i].clone() & carry[i].clone()),
@@ -527,19 +558,21 @@ impl SymbolicBitVec {
         positive_overflow | negative_overflow
     }
 
-    pub fn less_than(self, rhs: Self) -> SymbolicBit {
+    pub fn less_than(mut self, mut rhs: Self) -> SymbolicBit {
         assert_eq!(self.len(), rhs.len());
-        let mut lhs = self;
-        let mut rhs = rhs;
-        let lhs_msb = lhs.bits.pop().unwrap();
-        let rhs_msb = rhs.bits.pop().unwrap();
+        if self.is_empty() {
+            return FALSE;
+        }
+
+        let lhs_msb = self.bits.pop_back().unwrap();
+        let rhs_msb = rhs.bits.pop_back().unwrap();
         let less_than = lhs_msb.clone().equals(SymbolicBit::Literal(false))
             & rhs_msb.clone().equals(SymbolicBit::Literal(true));
 
-        if lhs.bits.len() > 0 {
-            less_than | (lhs_msb.equals(rhs_msb) & lhs.less_than(rhs))
-        } else {
+        if self.bits.is_empty() {
             less_than
+        } else {
+            less_than | (lhs_msb.equals(rhs_msb) & self.less_than(rhs))
         }
     }
 
@@ -547,19 +580,21 @@ impl SymbolicBitVec {
         self.clone().less_than(rhs.clone()) | self.equals(rhs)
     }
 
-    pub fn greater_than(self, rhs: Self) -> SymbolicBit {
+    pub fn greater_than(mut self, mut rhs: Self) -> SymbolicBit {
         assert_eq!(self.len(), rhs.len());
-        let mut lhs = self;
-        let mut rhs = rhs;
-        let lhs_msb = lhs.bits.pop().unwrap();
-        let rhs_msb = rhs.bits.pop().unwrap();
+        if self.is_empty() {
+            return FALSE;
+        }
+
+        let lhs_msb = self.bits.pop_back().unwrap();
+        let rhs_msb = rhs.bits.pop_back().unwrap();
         let greater_than = lhs_msb.clone().equals(SymbolicBit::Literal(true))
             & rhs_msb.clone().equals(SymbolicBit::Literal(false));
 
-        if lhs.bits.len() > 0 {
-            greater_than | (lhs_msb.equals(rhs_msb) & lhs.greater_than(rhs))
-        } else {
+        if self.is_empty() {
             greater_than
+        } else {
+            greater_than | (lhs_msb.equals(rhs_msb) & self.greater_than(rhs))
         }
     }
 
@@ -569,8 +604,12 @@ impl SymbolicBitVec {
 
     pub fn signed_less_than(self, rhs: Self) -> SymbolicBit {
         assert_eq!(self.len(), rhs.len());
-        let lhs_sign_bit = self[self.len() - 1].clone();
-        let rhs_sign_bit = rhs[rhs.len() - 1].clone();
+        if self.is_empty() {
+            return FALSE;
+        }
+
+        let lhs_sign_bit = self.msb().cloned().unwrap();
+        let rhs_sign_bit = rhs.msb().cloned().unwrap();
         let mixed_sign_case = lhs_sign_bit.clone().equals(SymbolicBit::Literal(true))
             & rhs_sign_bit.clone().equals(SymbolicBit::Literal(false));
         let same_sign_case = lhs_sign_bit.equals(rhs_sign_bit) & self.less_than(rhs);
@@ -617,7 +656,7 @@ impl SymbolicBitVec {
     }
 
     pub fn signed_shift_right(self, rhs: Self) -> Self {
-        let sign_bit = self.bits.last().unwrap().clone();
+        let sign_bit = self.msb().cloned().unwrap();
         let mut bit_shift_value = 1;
         let mut result = self;
         for bit in rhs.bits {
@@ -627,6 +666,33 @@ impl SymbolicBitVec {
         }
 
         result
+    }
+
+    fn shift_mut(&mut self, amount: usize, shift_in: SymbolicBit, direction: ShiftDirection) {
+        let len = self.len();
+
+        match direction {
+            ShiftDirection::Left => {
+                // [ 0 1 2 3 4 5 6 7 ] << 3
+                // [ x x x 0 1 2 3 4 ]
+                for i in (amount..len).rev() {
+                    self.bits.swap(i, i - amount);
+                }
+                for i in 0..usize::min(len, amount) {
+                    self.bits[i] = shift_in.clone();
+                }
+            }
+            ShiftDirection::Right => {
+                // [ 0 1 2 3 4 5 6 7 ] >> 3
+                // [ 3 4 5 6 7 x x x ]
+                for i in amount..len {
+                    self.bits.swap(i, i - amount);
+                }
+                for i in 0..usize::min(len, amount) {
+                    self.bits[len - 1 - i] = shift_in.clone();
+                }
+            }
+        }
     }
 
     fn shift(&self, amount: usize, shift_in: SymbolicBit, is_left_shift: bool) -> Self {
@@ -660,11 +726,23 @@ impl SymbolicBitVec {
         }
     }
 
+    fn mux_mut(&mut self, rhs: Self, selector: SymbolicBit) {
+        rhs.bits.into_iter().enumerate().for_each(|(i, rhs)| {
+            let lhs = std::mem::take(&mut self.bits[i]);
+            self.bits[i] = selector.clone().select(lhs, rhs);
+        });
+    }
+
     fn mux(self, rhs: Self, selector: SymbolicBit) -> Self {
         let positive = vec![selector.clone(); self.len()].into_iter().collect();
         let negative = vec![!selector; self.len()].into_iter().collect();
         (self & positive) | (rhs & negative)
     }
+}
+
+enum ShiftDirection {
+    Left,
+    Right,
 }
 
 impl std::ops::Not for SymbolicBitVec {
@@ -686,7 +764,7 @@ impl std::ops::BitAnd for SymbolicBitVec {
             bits: self
                 .bits
                 .into_iter()
-                .zip(rhs.bits.into_iter())
+                .zip(rhs.bits)
                 .map(|(lhs, rhs)| lhs & rhs)
                 .collect(),
         }
@@ -702,7 +780,7 @@ impl std::ops::BitOr for SymbolicBitVec {
             bits: self
                 .bits
                 .into_iter()
-                .zip(rhs.bits.into_iter())
+                .zip(rhs.bits)
                 .map(|(lhs, rhs)| lhs | rhs)
                 .collect(),
         }
@@ -718,7 +796,7 @@ impl std::ops::BitXor for SymbolicBitVec {
             bits: self
                 .bits
                 .into_iter()
-                .zip(rhs.bits.into_iter())
+                .zip(rhs.bits)
                 .map(|(lhs, rhs)| lhs ^ rhs)
                 .collect(),
         }
@@ -728,49 +806,69 @@ impl std::ops::BitXor for SymbolicBitVec {
 impl std::ops::Shl<usize> for SymbolicBitVec {
     type Output = Self;
 
-    fn shl(self, rhs: usize) -> Self::Output {
-        let num_bits = self.bits.len();
-        let mut bits = Vec::with_capacity(num_bits);
-        let rhs = usize::min(rhs, num_bits);
-        for _ in 0..rhs {
-            bits.push(SymbolicBit::Literal(false));
-        }
-        bits.append(&mut self.bits[..num_bits - rhs].to_vec());
-
-        Self { bits }
+    fn shl(mut self, rhs: usize) -> Self::Output {
+        self <<= rhs;
+        self
     }
 }
 
 impl std::ops::Shl for SymbolicBitVec {
     type Output = Self;
 
-    fn shl(self, rhs: Self) -> Self::Output {
-        let mut bit_shift_value = 1;
-        let mut result = self;
-        for bit in rhs.bits {
-            let shifted_value = result.shift(bit_shift_value, SymbolicBit::Literal(false), true);
-            result = shifted_value.mux(result, bit);
-            bit_shift_value <<= 1;
-        }
+    fn shl(mut self, rhs: Self) -> Self::Output {
+        self <<= rhs;
+        self
+    }
+}
 
-        result
+impl std::ops::ShlAssign<usize> for SymbolicBitVec {
+    fn shl_assign(&mut self, rhs: usize) {
+        self.shift_mut(rhs, SymbolicBit::Literal(false), ShiftDirection::Left);
+    }
+}
+
+impl std::ops::ShlAssign for SymbolicBitVec {
+    fn shl_assign(&mut self, rhs: Self) {
+        for (i, shift_bit) in rhs.bits.into_iter().enumerate() {
+            let mut shifted_value = self.clone();
+            shifted_value.shift_mut(1 << i, SymbolicBit::Literal(false), ShiftDirection::Left);
+            self.mux_mut(shifted_value, !shift_bit);
+        }
     }
 }
 
 /// Performs an _unsigned_ right shift.
+impl std::ops::ShrAssign for SymbolicBitVec {
+    fn shr_assign(&mut self, rhs: Self) {
+        for (i, shift_bit) in rhs.bits.into_iter().enumerate() {
+            let mut shifted_value = self.clone();
+            shifted_value.shift_mut(1 << i, SymbolicBit::Literal(false), ShiftDirection::Right);
+            self.mux_mut(shifted_value, !shift_bit);
+        }
+    }
+}
+
+impl std::ops::ShrAssign<usize> for SymbolicBitVec {
+    fn shr_assign(&mut self, rhs: usize) {
+        self.shift_mut(rhs, SymbolicBit::Literal(false), ShiftDirection::Right);
+    }
+}
+
 impl std::ops::Shr for SymbolicBitVec {
     type Output = Self;
 
-    fn shr(self, rhs: Self) -> Self::Output {
-        let mut bit_shift_value = 1;
-        let mut result = self;
-        for bit in rhs.bits {
-            let shifted_value = result.shift(bit_shift_value, SymbolicBit::Literal(false), false);
-            result = shifted_value.mux(result, bit);
-            bit_shift_value <<= 1;
-        }
+    fn shr(mut self, rhs: Self) -> Self::Output {
+        self >>= rhs;
+        self
+    }
+}
 
-        result
+impl std::ops::Shr<usize> for SymbolicBitVec {
+    type Output = Self;
+
+    fn shr(mut self, rhs: usize) -> Self::Output {
+        self >>= rhs;
+        self
     }
 }
 
@@ -808,7 +906,11 @@ impl std::ops::Mul for SymbolicBitVec {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
+        // The output size is the sum of the number of bits. Clippy is overly zealous here flagging
+        // the addition as erroneous.
+        #[allow(clippy::suspicious_arithmetic_impl)]
         let output_size = self.len() + rhs.len();
+
         self.multiply(rhs, output_size)
     }
 }


### PR DESCRIPTION
This change updated the internals of `SymbolicBitVec` to use a `VecDeque` instead of a `Vec`. This helped improve performance for multiply and divide APIs. Also ported the shift implementations from `SymbolicBitBuf`, which resulted in marked improvements to the shift left and shift right APIs.

This change also removed some conversions from `SymbolicBitVec`. Converting directly to a `SymbolicBit` was not used in practice, so this was removed. This can still be achieved using `len() == 1` and `msb()`.

Additionally the `Deref` implementation into a slice has been removed, since a `VecDeque` cannot make the same contiguous guarantees. The common APIs used such as `len`, `is_empty`, and the `Index` trait impl have been implemented directly on `SymbolicBitVec` instead.

Resolves #57 
Resolves #95