### PR TITLE
Only package Ghidra portion of libsla in libsla crate

### DIFF
--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -17,7 +17,6 @@ include = [
     "ghidra/DISCLAIMER.md",
     "ghidra/NOTICE",
     "ghidra/LICENSE",
-    "ghidra/licenses/*",
 ]
 
 [dependencies]

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -8,9 +8,22 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+# List includes to avoid including entire Ghidra submodule
+include = [
+    "Cargo.toml",
+    "build.rs",
+    "src/*",
+    "ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",
+    "ghidra/DISCLAIMER.md",
+    "ghidra/NOTICE",
+    "ghidra/LICENSE",
+    "ghidra/licenses/*",
+]
+
 [dependencies]
 cxx = "1.0"
 thiserror.workspace = true
 
 [build-dependencies]
 cxx-build = "1.0"
+

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -14,6 +14,10 @@ include = [
     "build.rs",
     "src/*",
     "ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",
+    "ghidra/DISCLAIMER.md",
+    "ghidra/NOTICE",
+    "ghidra/LICENSE",
+    "ghidra/licenses/*",
 ]
 
 [dependencies]

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -17,6 +17,7 @@ include = [
     "ghidra/DISCLAIMER.md",
     "ghidra/NOTICE",
     "ghidra/LICENSE",
+    "ghidra/licenses/*",
 ]
 
 [dependencies]

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -14,10 +14,6 @@ include = [
     "build.rs",
     "src/*",
     "ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",
-    "ghidra/DISCLAIMER.md",
-    "ghidra/NOTICE",
-    "ghidra/LICENSE",
-    "ghidra/licenses/*",
 ]
 
 [dependencies]


### PR DESCRIPTION
Do not want to commit the entire Ghidra submodule into the crate package on publish. License files are included as well since Ghidra license, while published under Apache-2.0, contains a NOTICE that should be redistributed according to the LICENSE.