### PR TITLE
Fix package path in Cargo.toml including additional files from Ghidra

### DIFF
--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 # List includes to avoid including entire Ghidra submodule
 include = [
     "Cargo.toml",
-    "README.md",
+    "/README.md",
     "build.rs",
     "src/*",
     "ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -10,15 +10,15 @@ repository.workspace = true
 
 # List includes to avoid including entire Ghidra submodule
 include = [
-    "Cargo.toml",
+    "/Cargo.toml",
     "/README.md",
-    "build.rs",
-    "src/*",
-    "ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",
-    "ghidra/DISCLAIMER.md",
-    "ghidra/NOTICE",
-    "ghidra/LICENSE",
-    "ghidra/licenses/*",
+    "/build.rs",
+    "/src/*",
+    "/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",
+    "/ghidra/DISCLAIMER.md",
+    "/ghidra/NOTICE",
+    "/ghidra/LICENSE",
+    "/ghidra/licenses/*",
 ]
 
 [dependencies]


### PR DESCRIPTION
The newly added README.md path also picked up README.md paths from within Ghidra.