### PR TITLE
Use builder pattern for GhidraSleigh

### DIFF
--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsla"
 description = "Rust bindings to Ghidra Sleigh library libsla"
-version = "0.1.3"
+version = "0.2.0"
 
 authors.workspace = true
 edition.workspace = true 

--- a/crates/libsla/README.md
+++ b/crates/libsla/README.md
@@ -36,17 +36,17 @@ This gives an overview of the general structure for disassembling code into p-co
 example using x86-64 see the [sleigh unit tests](./src/sleigh.rs).
 
 ```rust
-// Construct new sleigh instance
-let mut sleigh = GhidraSleigh::new();
-
 // Compiled from x86-64.slaspec in Ghidra repository
 let slaspec = std::fs::read_to_string("x86-64.sla");
 
 // Located in Ghidra repository. No compilation necessary.
 let pspec = std::fs::read_to_string("x86-64.pspec");
 
-// Initialize sleigh. Required before decoding can be performed.
-sleigh.initialize(&slaspec, &pspec).expect("failed to initialize sleigh");
+// Construct new sleigh instance
+let sleigh = GhidraSleigh::builder()
+    .sleigh_spec(&slaspec)?
+    .processor_spec(&pspec)?
+    .build()?;
 
 // The instruction reader is defined by the user and implements the LoadImage trait.
 let instruction_reader = InstructionReader::new();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -161,16 +161,16 @@ impl TracingEmulator {
     }
 }
 
-pub fn x86_64_sleigh() -> GhidraSleigh {
-    let mut sleigh = GhidraSleigh::new();
+pub fn x86_64_sleigh() -> libsla::Result<GhidraSleigh> {
     let sleigh_spec =
         fs::read_to_string("data/x86-64.sla").expect("failed to read processor spec file");
     let processor_spec = fs::read_to_string(
         "../crates/libsla/ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec",
     )
     .expect("failed to read processor spec file");
-    sleigh
-        .initialize(&sleigh_spec, &processor_spec)
-        .expect("failed to initialize sleigh");
-    sleigh
+
+    GhidraSleigh::builder()
+        .sleigh_spec(&sleigh_spec)?
+        .processor_spec(&processor_spec)?
+        .build()
 }

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -18,7 +18,7 @@ fn processor_with_image(
     image: impl AsRef<Path>,
     entry: u64,
 ) -> ProcessorManager<TracingEmulator, Memory, ProcessorHandlerX86> {
-    let sleigh = x86_64_sleigh();
+    let sleigh = x86_64_sleigh().expect("failed to build sleigh");
     let mut memory = Memory::default();
 
     // Write image into memory
@@ -117,7 +117,7 @@ fn init_registers(sleigh: &impl Sleigh, memory: &mut Memory) {
 /// Confirms the functionality of general-purpose x86-64 registers and overlapping behavior.
 #[test]
 fn x86_64_registers() {
-    let sleigh = x86_64_sleigh();
+    let sleigh = x86_64_sleigh().expect("failed to build sleigh");
 
     let write_register = |memory: &mut Memory, name: &str, data: &[u8]| {
         let register = sleigh
@@ -245,7 +245,7 @@ fn x86_64_registers() {
 /// ram:000000000000000d | RET
 #[test]
 fn doubler_32b() -> processor::Result<()> {
-    let sleigh = x86_64_sleigh();
+    let sleigh = x86_64_sleigh().expect("failed to build sleigh");
     let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
     let mut memory = Memory::default();
     let base_addr = 0x84210000;
@@ -414,7 +414,7 @@ fn pcode_coverage() -> processor::Result<()> {
 
 #[test]
 fn z3_integration() -> processor::Result<()> {
-    let sleigh = x86_64_sleigh();
+    let sleigh = x86_64_sleigh().expect("failed to build sleigh");
     let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
     let mut memory = Memory::default();
     let write_register = |memory: &mut Memory, name: &str, data: &[u8]| {


### PR DESCRIPTION
The `GhidraSleigh` object required both a sleigh and processor specification to be provided in the `initialize` function before further functionality would ever succeed. This API is confusing since it does not enforce the correct sequence. By applying the typestate builder pattern here the compiler can enforce the necessary preconditions are met.

This requires a version bump because the `new` method for construction has been removed.