### PR TITLE
Fix coverage report showing as 0% in Github

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,5 +45,7 @@ jobs:
         --instr-profile=merged.profdata \
         --summary-only \
         --use-color \
-        --ignore-filename-regex='/.cargo/registry'
+        --ignore-filename-regex='/.cargo/registry' \
+        --ignore-filename-regex='rustc/'
+
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
         rustup component add llvm-tools-preview
         PATH=$(rustup show home | xargs -I '{}' find {} -name 'llvm-profdata' | xargs -I '{}' dirname {}):$PATH
         RUSTFLAGS="-C instrument-coverage" cargo test --workspace --lib
-        llvm-profdata merge -sparse default_*.profraw -o merged.profdata
+        llvm-profdata merge -sparse **/default_*.profraw -o merged.profdata
         llvm-cov report \
           $( \
             for file in \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,8 @@ jobs:
         rustup component add llvm-tools-preview
         PATH=$(rustup show home | xargs -I '{}' find {} -name 'llvm-profdata' | xargs -I '{}' dirname {}):$PATH
         RUSTFLAGS="-C instrument-coverage" cargo test --workspace --lib
-        llvm-profdata merge -sparse **/default_*.profraw -o merged.profdata
+        find . -name '*.profraw' > profraw-files.txt
+        llvm-profdata merge -sparse -f profraw-files.txt -o merged.profdata
         llvm-cov report \
           $( \
             for file in \


### PR DESCRIPTION
It looks like there was a change at some point that resulted in the generated `.profraw` files appearing in the crate roots instead of the workspace root. Or it's possible that the prior crate organization in this workspace was amenable to the default behavior but no longer is.

In either case the `.profraw` files appear in crate roots, so update the merge to find all of them.