### PR TITLE
Add method for constructing PcodeOps value from PcodeOps bit

### DIFF
--- a/crates/pcode-ops/src/ops.rs
+++ b/crates/pcode-ops/src/ops.rs
@@ -9,6 +9,9 @@ pub trait PcodeOps: BitwisePcodeOps + TryInto<u64> + FromIterator<Self::Byte> {
     /// A representation of a single bit.
     type Bit: BitwisePcodeOps + From<bool> + TryInto<bool> + std::fmt::Debug + Clone;
 
+    /// Create a value that is the given bit repeated to fill the specified number of bytes.
+    fn fill_bytes_with(bit: Self::Bit, num_bytes: usize) -> Self;
+
     /// Returns the number of bytes used to represent this value.
     fn num_bytes(&self) -> usize;
 
@@ -204,14 +207,6 @@ pub trait PcodeOps: BitwisePcodeOps + TryInto<u64> + FromIterator<Self::Byte> {
     /// than or equal to the unsigned integer input1, output is set to true. Both inputs must be the
     /// same size, and the output must have a size of 1.
     fn unsigned_greater_than_or_equals(self, rhs: Self) -> Self::Bit;
-
-    /// This evalutes the value predicated on the given condition. This is a bitwise conditional
-    /// evaluation. If the condition is false each bit of the value should evaluate to true.
-    fn predicated_on(self, condition: Self::Bit) -> Self;
-
-    /// This asserts the condition for the given value. This is a bitwise conditional evaluation.
-    /// If the condition is false each bit of the value should evaluate to false.
-    fn assert(self, condition: Self::Bit) -> Self;
 }
 
 /// Bitwise operations supported by pcode values.

--- a/crates/pcode-ops/src/pcode128.rs
+++ b/crates/pcode-ops/src/pcode128.rs
@@ -278,20 +278,10 @@ impl PcodeOps for Pcode128 {
         self.value() >= rhs.value()
     }
 
-    fn predicated_on(self, condition: Self::Bit) -> Self {
-        if condition {
-            self
-        } else {
-            Pcode128::new(self.bitmask(), self.valid_bits)
-        }
-    }
-
-    fn assert(self, condition: Self::Bit) -> Self {
-        if condition {
-            self
-        } else {
-            Pcode128::new(0, self.valid_bits)
-        }
+    fn fill_bytes_with(bit: Self::Bit, num_bytes: usize) -> Self {
+        std::iter::repeat(if bit { u8::MAX } else { 0 })
+            .take(num_bytes)
+            .collect()
     }
 
     fn into_le_bytes(self) -> impl ExactSizeIterator<Item = Self::Byte> {

--- a/crates/pcode/src/test_fixture.rs
+++ b/crates/pcode/src/test_fixture.rs
@@ -184,12 +184,8 @@ impl PcodeOps for SymbolicValue {
         self
     }
 
-    fn predicated_on(self, _condition: Self::Bit) -> Self {
-        self
-    }
-
-    fn assert(self, _condition: Self::Bit) -> Self {
-        self
+    fn fill_bytes_with(_bit: Self::Bit, _num_bytes: usize) -> Self {
+        Self::default()
     }
 }
 

--- a/crates/sym/src/pcode.rs
+++ b/crates/sym/src/pcode.rs
@@ -158,18 +158,10 @@ impl PcodeOps for SymbolicBitVec {
         self.greater_than_eq(other)
     }
 
-    fn predicated_on(self, condition: Self::Bit) -> Self {
-        std::iter::repeat(!condition)
-            .take(self.len())
-            .collect::<Self>()
-            | self
-    }
-
-    fn assert(self, condition: Self::Bit) -> Self {
-        std::iter::repeat(condition)
-            .take(self.len())
-            .collect::<Self>()
-            & self
+    fn fill_bytes_with(bit: Self::Bit, num_bytes: usize) -> Self {
+        std::iter::repeat(bit)
+            .take(u8::BITS as usize * num_bytes)
+            .collect()
     }
 }
 


### PR DESCRIPTION
The methods `predicated_on` and `assert` in `PcodeOps` did not translate to any actual pcode operation defined in the specification. However, these functions were necessary functions for exploring pcode execution contingent on branch conditions. This necessity was borne from the inability to construct a pcode value from a branch condition, specifically a value filled with that the branch condition bit.

This adds a new method `fill_bytes_with` to `PcodeOps` which creates a value with the specified number of bytes filled with the desired `PcodeOps::Bit`. The emulation now instead uses this more generic method -- which is both simpler to understand and implement.