### PR TITLE
Remove `TryInto<u64>` requirement from `PcodeOps`

### DIFF
--- a/crates/pcode-ops/Cargo.toml
+++ b/crates/pcode-ops/Cargo.toml
@@ -8,3 +8,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+thiserror.workspace = true

--- a/crates/pcode-ops/src/convert.rs
+++ b/crates/pcode-ops/src/convert.rs
@@ -1,5 +1,7 @@
 use std::ops::Deref;
 
+use crate::PcodeOps;
+
 #[derive(thiserror::Error, Debug)]
 pub enum TryFromPcodeValueError {
     #[error("pcode value exceeds size of target type")]
@@ -21,17 +23,23 @@ pub trait LittleEndian<const N: usize, T = u8> {
 
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct PcodeValue<T: crate::PcodeOps> {
+pub struct PcodeValue<T: PcodeOps> {
     inner: T,
 }
 
-impl<T: crate::PcodeOps> From<T> for PcodeValue<T> {
+impl<T: PcodeOps> PcodeValue<T> {
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T: PcodeOps> From<T> for PcodeValue<T> {
     fn from(value: T) -> Self {
         Self { inner: value }
     }
 }
 
-impl<T: crate::PcodeOps> Deref for PcodeValue<T> {
+impl<T: PcodeOps> Deref for PcodeValue<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -46,7 +54,7 @@ macro_rules! impl_tryfrom_pcodevalue {
         });
     };
     ($target:ty, $size:expr, $signed:expr) => {
-        impl<T: crate::PcodeOps> TryFrom<PcodeValue<T>> for $target {
+        impl<T: PcodeOps> TryFrom<PcodeValue<T>> for $target {
             type Error = TryFromPcodeValueError;
 
             fn try_from(pcode_value: PcodeValue<T>) -> Result<Self, Self::Error> {

--- a/crates/pcode-ops/src/convert.rs
+++ b/crates/pcode-ops/src/convert.rs
@@ -1,3 +1,14 @@
+use std::ops::Deref;
+
+#[derive(thiserror::Error, Debug)]
+pub enum TryFromPcodeValueError {
+    #[error("pcode value exceeds size of target type")]
+    SizeExceeded,
+
+    #[error("failed to convert byte at index {index}")]
+    InvalidByte { index: usize },
+}
+
 /// Little-endian representation of an object with a known size at compile-time. The default word
 /// size is a byte.
 pub trait LittleEndian<const N: usize, T = u8> {
@@ -6,6 +17,71 @@ pub trait LittleEndian<const N: usize, T = u8> {
 
     /// Convert self into an array of words.
     fn into_words(self) -> [T; N];
+}
+
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PcodeValue<T: crate::PcodeOps> {
+    inner: T,
+}
+
+impl<T: crate::PcodeOps> From<T> for PcodeValue<T> {
+    fn from(value: T) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl<T: crate::PcodeOps> Deref for PcodeValue<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+macro_rules! impl_tryfrom_pcodevalue {
+    ($target:ty) => {
+        impl_tryfrom_pcodevalue!($target, { std::mem::size_of::<$target>() }, {
+            stringify!($target).starts_with("i")
+        });
+    };
+    ($target:ty, $size:expr, $signed:expr) => {
+        impl<T: crate::PcodeOps> TryFrom<PcodeValue<T>> for $target {
+            type Error = TryFromPcodeValueError;
+
+            fn try_from(pcode_value: PcodeValue<T>) -> Result<Self, Self::Error> {
+                const BYTES: usize = (<$target>::BITS / u8::BITS) as usize;
+                let pcode_value = match usize::cmp(&pcode_value.num_bytes(), &BYTES) {
+                    std::cmp::Ordering::Less => {
+                        if $signed {
+                            pcode_value.inner.sign_extend(BYTES).into()
+                        } else {
+                            pcode_value.inner.zero_extend(BYTES).into()
+                        }
+                    }
+                    std::cmp::Ordering::Equal => pcode_value,
+                    std::cmp::Ordering::Greater => {
+                        return Err(TryFromPcodeValueError::SizeExceeded)
+                    }
+                };
+
+                let bytes = pcode_value
+                    .inner
+                    .into_le_bytes()
+                    .enumerate()
+                    .map(|(index, byte)| {
+                        byte.try_into()
+                            .map_err(|_| TryFromPcodeValueError::InvalidByte { index })
+                    })
+                    .collect::<Result<Vec<u8>, _>>()?;
+
+                let bytes = bytes
+                    .try_into()
+                    .map_err(|_| TryFromPcodeValueError::SizeExceeded)?;
+                Ok(<$target>::from_le_bytes(bytes))
+            }
+        }
+    };
 }
 
 macro_rules! impl_little_endian {
@@ -24,6 +100,19 @@ macro_rules! impl_little_endian {
         }
     };
 }
+
+impl_tryfrom_pcodevalue!(usize);
+impl_tryfrom_pcodevalue!(u128);
+impl_tryfrom_pcodevalue!(u64);
+impl_tryfrom_pcodevalue!(u32);
+impl_tryfrom_pcodevalue!(u16);
+impl_tryfrom_pcodevalue!(u8);
+impl_tryfrom_pcodevalue!(isize);
+impl_tryfrom_pcodevalue!(i128);
+impl_tryfrom_pcodevalue!(i64);
+impl_tryfrom_pcodevalue!(i32);
+impl_tryfrom_pcodevalue!(i16);
+impl_tryfrom_pcodevalue!(i8);
 
 impl_little_endian!(usize);
 impl_little_endian!(u128);

--- a/crates/pcode-ops/src/convert.rs
+++ b/crates/pcode-ops/src/convert.rs
@@ -23,7 +23,18 @@ pub trait LittleEndian<const N: usize, T = u8> {
     fn into_words(self) -> [T; N];
 }
 
-/// Wrapper around a value that implements [PcodeOps].
+/// Wrapper around a value that implements [PcodeOps]. This wrapper supports conversions of pcode
+/// values to primitive types.
+///
+/// ## Example type conversion
+///
+/// ```
+/// # use pcode_ops::{convert::PcodeValue, Pcode128};
+/// let pcode128 = Pcode128::from(u64::MAX);
+/// let pcode_value = PcodeValue::from(pcode128);
+/// let value: u64 = pcode_value.try_into().unwrap();
+/// assert_eq!(value, u64::MAX);
+/// ```
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PcodeValue<T: PcodeOps> {

--- a/crates/pcode-ops/src/ops.rs
+++ b/crates/pcode-ops/src/ops.rs
@@ -2,7 +2,7 @@
 /// is not prescribed, several of the operations assume the ability to reason about the bytes of
 /// the value. In some cases the value may be interpreted as a boolean value as the result of a
 /// condition evaluation.
-pub trait PcodeOps: BitwisePcodeOps + TryInto<u64> + FromIterator<Self::Byte> {
+pub trait PcodeOps: BitwisePcodeOps + FromIterator<Self::Byte> {
     /// A representation of a byte (8-bit) value.
     type Byte: From<u8> + TryInto<u8> + Clone + From<Self::Bit>;
 

--- a/crates/pcode/src/emulator.rs
+++ b/crates/pcode/src/emulator.rs
@@ -2,7 +2,7 @@ use libsla::{
     Address, AddressSpace, AddressSpaceId, AddressSpaceType, BoolOp, IntOp, IntSign, OpCode,
     PcodeInstruction, VarnodeData,
 };
-use pcode_ops::{BitwisePcodeOps, PcodeOps};
+use pcode_ops::{convert::PcodeValue, BitwisePcodeOps, PcodeOps};
 use thiserror;
 
 use crate::mem::{self, VarnodeDataStore};
@@ -670,8 +670,9 @@ impl StandardPcodeEmulator {
         require_input_size_equals(instruction, input_index, target_space.address_size)?;
 
         // Get concrete bytes. Can return an error if byte is symbolic
-        memory
-            .read(&instruction.inputs[input_index])?
+        let value = memory.read(&instruction.inputs[input_index])?;
+        let value = PcodeValue::from(value);
+        value
             .try_into()
             .map_err(|_err| Error::IndirectAddressOffset {
                 instruction: Box::new(instruction.clone()),


### PR DESCRIPTION
This requirement was largely required for the emulator to convert values into offsets for indirect branches. However all the machinery is already in place to accomplish this without requiring `TryInto<u64>`. It also strangely specialized the requirement around `u64` but did not have support for other values, leading to awkward usage in those cases.

The direct requirement has been removed and replaced with a wrapper `PcodeValue` for integral type conversions. This is used for `u64` in the emulator (replacing the direct `TryInto<u64>` conversion). It also simplified the x86 emulator integration test conversion logic which needed to convert to `u128`.