### PR TITLE
Add register_name to Sleigh

### DIFF
--- a/crates/libsla/src/ffi/sys.rs
+++ b/crates/libsla/src/ffi/sys.rs
@@ -304,6 +304,7 @@ mod default {
         #[rust_name = "register_from_name"]
         fn getRegister<'a>(self: &'a SleighProxy, name: &CxxString) -> Result<&'a VarnodeData>;
 
+        // This will return an empty string on failure
         #[rust_name = "register_name"]
         unsafe fn getRegisterNameProxy(
             self: &SleighProxy,

--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("dependency error: {message} caused by {source}")]
     DependencyError {
         message: Cow<'static, str>,
-        source: Box<dyn std::error::Error + Send + Sync>,
+        source: Box<dyn std::error::Error>,
     },
 
     #[error("internal error: {0}")]

--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -68,7 +68,8 @@ pub trait Sleigh {
         address: Address,
     ) -> Result<Disassembly<AssemblyInstruction>>;
 
-    /// Get the register name for a varnode targeting a register
+    /// Get the register name for a varnode targeting a register. This will return `None` if the
+    /// target is not a valid register.
     fn register_name(&self, target: &VarnodeData) -> Option<String>;
 }
 
@@ -665,8 +666,16 @@ impl Sleigh for GhidraSleigh {
         addr_spaces
     }
 
+    /// Get the register name for a varnode targeting a register. This will return `None` if the
+    /// target is not a valid register.
     fn register_name(&self, target: &VarnodeData) -> Option<String> {
         let base = self.sys_address_space(target.address.address_space.id)?;
+
+        // If offset + size overflows then Ghidra can accidentally match a register
+        //
+        // See getRegisterName in ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/sleighbase.cc
+        let _ = target.address.offset.checked_add(target.size as u64)?;
+
         let register_name = unsafe {
             self.sleigh
                 .register_name(base, target.address.offset, target.size as i32)

--- a/crates/libsla/src/tests/sleigh.rs
+++ b/crates/libsla/src/tests/sleigh.rs
@@ -43,23 +43,25 @@ fn dump_pcode_response(response: &Disassembly<PcodeInstruction>) {
     }
 }
 
+fn x86_64_sleigh() -> Result<GhidraSleigh> {
+    let sleigh_spec = fs::read_to_string("../../tests/data/x86-64.sla")
+        .expect("Failed to read processor spec file");
+    let processor_spec =
+        fs::read_to_string("ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec")
+            .expect("Failed to read processor spec file");
+    let sleigh = GhidraSleigh::builder()
+        .sleigh_spec(&sleigh_spec)?
+        .processor_spec(&processor_spec)?
+        .build()?;
+    Ok(sleigh)
+}
+
 #[test]
 fn test_pcode() -> Result<()> {
     const NUM_INSTRUCTIONS: usize = 7;
     let load_image =
         LoadImageImpl(b"\x55\x48\x89\xe5\x89\x7d\xfc\x8b\x45\xfc\x0f\xaf\xc0\x5d\xc3".to_vec());
-    let sleigh_spec =
-        fs::read_to_string("../../tests/data/x86-64.sla").expect("Failed to read sleigh spec file");
-
-    let processor_spec =
-        fs::read_to_string("ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec")
-            .expect("Failed to read processor spec file");
-
-    let sleigh = GhidraSleigh::builder()
-        .sleigh_spec(&sleigh_spec)?
-        .processor_spec(&processor_spec)?
-        .build()?;
-
+    let sleigh = x86_64_sleigh()?;
     let mut offset = 0;
     for _ in 0..NUM_INSTRUCTIONS {
         let address = Address {
@@ -81,17 +83,7 @@ fn test_pcode() -> Result<()> {
 fn test_assembly() -> Result<()> {
     let load_image =
         LoadImageImpl(b"\x55\x48\x89\xe5\x89\x7d\xfc\x8b\x45\xfc\x01\xc0\x5d\xc3".to_vec());
-    let sleigh_spec = fs::read_to_string("../../tests/data/x86-64.sla")
-        .expect("Failed to read processor spec file");
-    let processor_spec =
-        fs::read_to_string("ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec")
-            .expect("Failed to read processor spec file");
-
-    let sleigh = GhidraSleigh::builder()
-        .sleigh_spec(&sleigh_spec)?
-        .processor_spec(&processor_spec)?
-        .build()?;
-
+    let sleigh = x86_64_sleigh()?;
     let mut offset = 0;
     let expected = vec![
         ("ram".to_string(), 0, "PUSH".to_string(), "RBP".to_string()),
@@ -149,21 +141,31 @@ fn test_assembly() -> Result<()> {
 
 #[test]
 pub fn register_from_name() -> Result<()> {
-    let sleigh_spec = fs::read_to_string("../../tests/data/x86-64.sla")
-        .expect("Failed to read processor spec file");
-    let processor_spec =
-        fs::read_to_string("ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec")
-            .expect("Failed to read processor spec file");
-
-    let sleigh = GhidraSleigh::builder()
-        .sleigh_spec(&sleigh_spec)?
-        .processor_spec(&processor_spec)?
-        .build()?;
-
+    let sleigh = x86_64_sleigh()?;
     let rax = sleigh.register_from_name("RAX").expect("invalid register");
     assert_eq!(rax.address.address_space.name, "register");
     assert_eq!(rax.address.offset, 0);
     assert_eq!(rax.size, 8);
+    assert_eq!(sleigh.register_name(&rax), Some("RAX".to_string()));
+    Ok(())
+}
+
+#[test]
+pub fn register_name_of_non_register() -> Result<()> {
+    let sleigh = x86_64_sleigh()?;
+    let mut register = sleigh
+        .register_from_name("RAX")
+        .expect("RAX should be a valid register");
+
+    // Change offset to something absurd
+    // Note that the lookup will perform offset + size without overflow checks
+    // so this value cannot be TOO absurd or else it will overflow into a normal value
+    //
+    // See ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/sleighbase.cc
+    register.address.offset = u64::MAX - register.size as u64;
+
+    let result = sleigh.register_name(&register);
+    assert!(result.is_none(), "{result:?} should be None");
     Ok(())
 }
 
@@ -203,16 +205,7 @@ pub fn addr_space_type() -> Result<()> {
 
 #[test]
 pub fn invalid_register_name() -> Result<()> {
-    let sleigh_spec = fs::read_to_string("../../tests/data/x86-64.sla")
-        .expect("Failed to read processor spec file");
-    let processor_spec =
-        fs::read_to_string("ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec")
-            .expect("Failed to read processor spec file");
-    let sleigh = GhidraSleigh::builder()
-        .sleigh_spec(&sleigh_spec)?
-        .processor_spec(&processor_spec)?
-        .build()?;
-
+    let sleigh = x86_64_sleigh()?;
     let invalid_register_name = "invalid_register";
     let err = sleigh
         .register_from_name(invalid_register_name)
@@ -235,15 +228,7 @@ pub fn invalid_register_name() -> Result<()> {
 #[test]
 pub fn insufficient_data() -> Result<()> {
     let load_image = LoadImageImpl(b"\x00".to_vec());
-    let sleigh_spec = fs::read_to_string("../../tests/data/x86-64.sla")
-        .expect("Failed to read processor spec file");
-    let processor_spec =
-        fs::read_to_string("ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec")
-            .expect("Failed to read processor spec file");
-    let sleigh = GhidraSleigh::builder()
-        .sleigh_spec(&sleigh_spec)?
-        .processor_spec(&processor_spec)?
-        .build()?;
+    let sleigh = x86_64_sleigh()?;
     let offset = 0;
     let address = Address {
         offset,
@@ -263,15 +248,7 @@ pub fn insufficient_data() -> Result<()> {
 #[test]
 pub fn invalid_instruction() -> Result<()> {
     let load_image = LoadImageImpl(std::iter::repeat_n(0xFF, 16).collect());
-    let sleigh_spec = fs::read_to_string("../../tests/data/x86-64.sla")
-        .expect("Failed to read processor spec file");
-    let processor_spec =
-        fs::read_to_string("ghidra/Ghidra/Processors/x86/data/languages/x86-64.pspec")
-            .expect("Failed to read processor spec file");
-    let sleigh = GhidraSleigh::builder()
-        .sleigh_spec(&sleigh_spec)?
-        .processor_spec(&processor_spec)?
-        .build()?;
+    let sleigh = x86_64_sleigh()?;
     let offset = 0;
     let address = Address {
         offset,


### PR DESCRIPTION
This API enables one to determine the register name from a given `VarnodeData`. This is primarily useful for debugging. For example, if a register read fails on a `VarnodeData` obtained from an instruction, `sleigh.register_name(&failing_varnode)` can determine the register name for further triage.