### PR TITLE
Add PcodeValue conversions to byte buffers

### DIFF
--- a/crates/pcode-ops/src/tests.rs
+++ b/crates/pcode-ops/src/tests.rs
@@ -1,1 +1,2 @@
+mod convert;
 mod pcode128;

--- a/crates/pcode-ops/src/tests/convert.rs
+++ b/crates/pcode-ops/src/tests/convert.rs
@@ -1,0 +1,46 @@
+use crate::convert::{PcodeValue, TryFromPcodeValueError};
+use crate::pcode128::Pcode128;
+
+#[test]
+fn into_byte_buffer() -> Result<(), TryFromPcodeValueError> {
+    let value = PcodeValue::from(Pcode128::new(u64::MAX.into(), u64::BITS));
+    let bytes: [u8; 8] = value.try_into()?;
+    for byte in bytes {
+        assert_eq!(byte, 0xff);
+    }
+    Ok(())
+}
+
+#[test]
+fn into_byte_buffer_too_small() -> Result<(), TryFromPcodeValueError> {
+    let value = PcodeValue::from(Pcode128::new(u64::MAX.into(), u64::BITS));
+    let result: Result<[u8; 7], _> = value.try_into();
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        TryFromPcodeValueError::InvalidSize
+    ));
+    Ok(())
+}
+
+#[test]
+fn into_byte_buffer_too_big() -> Result<(), TryFromPcodeValueError> {
+    let value = PcodeValue::from(Pcode128::new(u64::MAX.into(), u64::BITS));
+    let result: Result<[u8; 9], _> = value.try_into();
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        TryFromPcodeValueError::InvalidSize
+    ));
+    Ok(())
+}
+
+#[test]
+fn into_vec() -> Result<(), TryFromPcodeValueError> {
+    let value = PcodeValue::from(Pcode128::new(u64::MAX.into(), u64::BITS));
+    let bytes: Vec<u8> = value.try_into()?;
+    for byte in bytes {
+        assert_eq!(byte, 0xff);
+    }
+    Ok(())
+}


### PR DESCRIPTION
This can be used in instances where the target type is not a primitive.