### PR TITLE
Add Send + Sync to libsla DependencyError source

### DIFF
--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("dependency error: {message} caused by {source}")]
     DependencyError {
         message: Cow<'static, str>,
-        source: Box<dyn std::error::Error>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     #[error("internal error: {0}")]


### PR DESCRIPTION
This is required to convert `Error` to the error type of other reporting frameworks such as `eyre`.