### PR TITLE
Build test fixtures for integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,16 +20,6 @@ jobs:
         submodules: recursive
     - name: Build
       run: cargo build --verbose --all-targets
-    - name: Build Pcode Coverage Test Fixture
-      run: |
-        rustup target add x86_64-unknown-none
-        cargo build
-      working-directory: ./tests/test-fixtures/pcode-coverage
-    - name: Build Linux Syscalls Test Fixture
-      run: |
-        rustup target add x86_64-unknown-linux-musl
-        cargo build
-      working-directory: ./tests/test-fixtures/linux-syscalls
     - name: Unit Tests
       run: cargo test --workspace --verbose
     - name: Coverage Report

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,10 @@ jobs:
         submodules: recursive
     - name: Build
       run: cargo build --verbose --all-targets
+    - name: Add test fixture targets
+      run: |
+        rustup target add x86_64-unknown-none
+        rustup target add x86_64-unknown-linux-musl
     - name: Unit Tests
       run: cargo test --workspace --verbose
     - name: Coverage Report

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,6 +17,9 @@ sym = { path = "../crates/sym" }
 [dev-dependencies]
 elf = "0.8"
 
+# For building test fixtures
+escargot = "0.5"
+
 # This requires z3 to be installed locally as a shared library.
 z3 = "0.12"
 

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -200,6 +200,33 @@ fn init_registers(sleigh: &impl Sleigh, memory: &mut Memory) {
         .expect("failed to init DF register");
 }
 
+fn find_test_fixture(
+    messages: escargot::CommandMessages,
+) -> Result<std::path::PathBuf, Vec<escargot::error::CargoResult<escargot::Message>>> {
+    let messages: Vec<_> = messages.into_iter().collect();
+    let executable_path = messages.iter().find_map(|result| {
+        result
+            .as_ref()
+            .ok()
+            .into_iter()
+            .filter_map(|msg| {
+                msg.decode()
+                    .ok()
+                    .into_iter()
+                    .filter_map(|msg| match msg {
+                        escargot::format::Message::CompilerArtifact(artifact) => {
+                            artifact.executable.map(|p| p.into_owned())
+                        }
+                        _ => None,
+                    })
+                    .next()
+            })
+            .next()
+    });
+
+    executable_path.ok_or(messages)
+}
+
 /// Confirms the functionality of general-purpose x86-64 registers and overlapping behavior.
 #[test]
 fn x86_64_registers() {
@@ -418,7 +445,7 @@ fn doubler_32b() -> processor::Result<()> {
 #[test]
 fn hello_world_linux() -> processor::Result<()> {
     // Build test fixture first
-    escargot::CargoBuild::new()
+    let messages = escargot::CargoBuild::new()
         .bin("linux-syscalls")
         .manifest_path("./test-fixtures/linux-syscalls/Cargo.toml")
         .target("x86_64-unknown-linux-musl")
@@ -429,8 +456,13 @@ fn hello_world_linux() -> processor::Result<()> {
         .exec()
         .unwrap();
 
-    let image =
-        "./test-fixtures/linux-syscalls/target/x86_64-unknown-linux-musl/debug/linux-syscalls";
+    let image = match find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
     let sleigh = Rc::new(x86_64_sleigh().expect("failed to build sleigh"));
     let mut memory = memory_with_image(&sleigh, image);
     init_registers(sleigh.as_ref(), &mut memory);
@@ -481,15 +513,21 @@ fn hello_world_linux() -> processor::Result<()> {
 #[test]
 fn pcode_coverage() -> processor::Result<()> {
     // Build test fixture first
-    escargot::CargoBuild::new()
+    let messages = escargot::CargoBuild::new()
         .bin("pcode-coverage")
         .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
         .target("x86_64-unknown-none")
         .exec()
         .unwrap();
 
+    let image = match find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
     let sleigh = x86_64_sleigh().expect("failed to build sleigh");
-    let image = "./test-fixtures/pcode-coverage/target/x86_64-unknown-none/debug/pcode-coverage";
     let mut memory = memory_with_image(&sleigh, image);
     init_registers(&sleigh, &mut memory);
 

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -417,6 +417,18 @@ fn doubler_32b() -> processor::Result<()> {
 
 #[test]
 fn hello_world_linux() -> processor::Result<()> {
+    // Build test fixture first
+    escargot::CargoBuild::new()
+        .bin("linux-syscalls")
+        .manifest_path("./test-fixtures/linux-syscalls/Cargo.toml")
+        .target("x86_64-unknown-linux-musl")
+        .env(
+            "RUSTFLAGS",
+            "-Ctarget-feature=+crt-static -Crelocation-model=static",
+        )
+        .exec()
+        .unwrap();
+
     let image =
         "./test-fixtures/linux-syscalls/target/x86_64-unknown-linux-musl/debug/linux-syscalls";
     let sleigh = Rc::new(x86_64_sleigh().expect("failed to build sleigh"));
@@ -468,7 +480,14 @@ fn hello_world_linux() -> processor::Result<()> {
 
 #[test]
 fn pcode_coverage() -> processor::Result<()> {
-    // TODO Must first ensure target is built. Currently must be done manually
+    // Build test fixture first
+    escargot::CargoBuild::new()
+        .bin("pcode-coverage")
+        .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
+        .target("x86_64-unknown-none")
+        .exec()
+        .unwrap();
+
     let sleigh = x86_64_sleigh().expect("failed to build sleigh");
     let image = "./test-fixtures/pcode-coverage/target/x86_64-unknown-none/debug/pcode-coverage";
     let mut memory = memory_with_image(&sleigh, image);


### PR DESCRIPTION
Some of the integration tests depend on test fixtures that need to be built before the test can run. This change makes it so that this is handled by the test automatically instead of needing the test fixtures to be built externally.

Resolves #161 