### PR TITLE
Rename `registers` to `register_name_map`

### DIFF
--- a/crates/libsla/src/ffi/sys.rs
+++ b/crates/libsla/src/ffi/sys.rs
@@ -324,7 +324,7 @@ mod default {
         // cxx crate does not expose std::map. So the FFI layer builds a vector of the map
         // key-value pairs instead in a custom class. The custom layer is necessary since the pair
         // API cannot be easily exposed through FFI either.
-        #[rust_name = "registers"]
+        #[rust_name = "all_register_names"]
         fn getAllRegistersProxy(self: &SleighProxy) -> UniquePtr<CxxVector<RegisterVarnodeName>>;
 
         #[rust_name = "parse_processor_config"]

--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -74,7 +74,7 @@ pub trait Sleigh {
     fn register_name(&self, target: &VarnodeData) -> Option<String>;
 
     /// Get a sorted map of registers to register names.
-    fn registers(&self) -> BTreeMap<VarnodeData, String>;
+    fn all_register_names(&self) -> BTreeMap<VarnodeData, String>;
 }
 
 /// An address is represented by an offset into an address space
@@ -744,9 +744,9 @@ impl Sleigh for GhidraSleigh {
         Ok(Disassembly::new(instructions, origin))
     }
 
-    fn registers(&self) -> BTreeMap<VarnodeData, String> {
+    fn all_register_names(&self) -> BTreeMap<VarnodeData, String> {
         self.sleigh
-            .registers()
+            .all_register_names()
             .into_iter()
             .map(|data| (data.register().into(), data.name().to_string()))
             .collect()

--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -74,7 +74,7 @@ pub trait Sleigh {
     fn register_name(&self, target: &VarnodeData) -> Option<String>;
 
     /// Get a sorted map of registers to register names.
-    fn all_register_names(&self) -> BTreeMap<VarnodeData, String>;
+    fn register_name_map(&self) -> BTreeMap<VarnodeData, String>;
 }
 
 /// An address is represented by an offset into an address space
@@ -744,7 +744,7 @@ impl Sleigh for GhidraSleigh {
         Ok(Disassembly::new(instructions, origin))
     }
 
-    fn all_register_names(&self) -> BTreeMap<VarnodeData, String> {
+    fn register_name_map(&self) -> BTreeMap<VarnodeData, String> {
         self.sleigh
             .all_register_names()
             .into_iter()

--- a/crates/libsla/src/tests/sleigh.rs
+++ b/crates/libsla/src/tests/sleigh.rs
@@ -290,7 +290,7 @@ pub fn invalid_instruction() -> Result<()> {
 fn all_register_names() -> Result<()> {
     let sleigh = x86_64_sleigh()?;
     let expected_name = ["RAX", "EAX", "AX", "AL"];
-    for (i, (reg, name)) in sleigh.all_register_names().iter().take(4).enumerate() {
+    for (i, (reg, name)) in sleigh.register_name_map().iter().take(4).enumerate() {
         assert_eq!(
             reg.address.offset, 0,
             "address offset should be 0 for {name}: {reg:?}"

--- a/crates/libsla/src/tests/sleigh.rs
+++ b/crates/libsla/src/tests/sleigh.rs
@@ -287,10 +287,10 @@ pub fn invalid_instruction() -> Result<()> {
 }
 
 #[test]
-fn registers() -> Result<()> {
+fn all_register_names() -> Result<()> {
     let sleigh = x86_64_sleigh()?;
     let expected_name = ["RAX", "EAX", "AX", "AL"];
-    for (i, (reg, name)) in sleigh.registers().iter().take(4).enumerate() {
+    for (i, (reg, name)) in sleigh.all_register_names().iter().take(4).enumerate() {
         assert_eq!(
             reg.address.offset, 0,
             "address offset should be 0 for {name}: {reg:?}"


### PR DESCRIPTION
It was not immediately clear from `registers` that it not only enumerated the registers but also their names. The function has been renamed to `register_name_map` to improve clarity here.