### PR TITLE
Updated README to point to new sleigh compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nothing here yet.
 
+## libsla-0.3.1
+
+### Changed
+
+* Updated documentation regarding compilation of `.sla` files. Can now build `.sla` files from Rust using [sleigh-compiler](https://crates.io/crates/sleigh-compiler) crate.
+
 ## libsla-0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A _compiled_ Sleigh specification (.sla file) is required to translate native co
 
 ## Sleigh Compiler
 
-The sleigh compiler must be built from the [Ghidra decompiler source](https://github.com/NationalSecurityAgency/ghidra/blob/stable/Ghidra/Features/Decompiler/src/decompile/cpp) using `make sleigh_opt`.
+The [sleigh-compiler](https://crates.io/crates/sleigh-compiler) crate can be used to compile files from Rust code. Alternatively the original sleigh compiler can be built from the [Ghidra decompiler source](https://github.com/NationalSecurityAgency/ghidra/blob/stable/Ghidra/Features/Decompiler/src/decompile/cpp) using `make sleigh_opt`.
 
 ## Compile Sleigh Processor Specification (.slaspec)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A _compiled_ Sleigh specification (.sla file) is required to translate native co
 
 ## Sleigh Compiler
 
-The [sleigh-compiler](https://crates.io/crates/sleigh-compiler) crate can be used to compile files from Rust code. Alternatively the original sleigh compiler can be built from the [Ghidra decompiler source](https://github.com/NationalSecurityAgency/ghidra/blob/stable/Ghidra/Features/Decompiler/src/decompile/cpp) using `make sleigh_opt`.
+The [sleigh-compiler](https://crates.io/crates/sleigh-compiler) crate can be used from Rust code to compile `.slaspec` files into `.sla` files. Alternatively the original sleigh compiler can be built from the [Ghidra decompiler source](https://github.com/NationalSecurityAgency/ghidra/blob/stable/Ghidra/Features/Decompiler/src/decompile/cpp) using `make sleigh_opt`.
 
 ## Compile Sleigh Processor Specification (.slaspec)
 

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsla"
 description = "Rust bindings to Ghidra Sleigh library libsla"
-version = "0.3.0"
+version = "0.3.1"
 
 authors.workspace = true
 edition.workspace = true 

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -10,8 +10,6 @@ repository.workspace = true
 
 # List includes to avoid including entire Ghidra submodule
 include = [
-    "/Cargo.toml",
-    "/README.md",
     "/build.rs",
     "/src/*",
     "/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",

--- a/crates/libsla/README.md
+++ b/crates/libsla/README.md
@@ -17,7 +17,8 @@ The relevant .slaspec file must be compiled using the Sleigh compiler to generat
 
 ## Sleigh Compiler
 
-The sleigh compiler must be built from the
+The sleigh compiler can be invoked from Rust code using the [sleigh-compiler](https://crates.io/crates/sleigh-compiler) crate.
+Alternatively the original compiler can be built from the
 [Ghidra decompiler source](https://github.com/NationalSecurityAgency/ghidra/blob/stable/Ghidra/Features/Decompiler/src/decompile/cpp)
 using `make sleigh_opt`.
 

--- a/crates/libsla/src/ffi/cpp/error_handling.hh
+++ b/crates/libsla/src/ffi/cpp/error_handling.hh
@@ -5,6 +5,29 @@
 #include "translate.hh"
 #include "xml.hh"
 
+// The following are errors thrown from the decompiler codebase.
+// Almost all of the errors are children of LowlevelError
+//
+// BadDataError : LowlevelError
+// DataUnavailError : LowlevelError
+// DuplicateFunctionError : RecovError
+// EvaluationError : LowlevelError
+// JavaError : LowlevelError
+// JumptableNotReachableError : LowlevelError
+// JumptableThunkError : LowlevelError
+// LowlevelError (error.hh)
+// ParamUnassignedError : LowlevelError
+// ParseError : LowlevelError
+// RecovError : LowlevelError
+// SleighError : LowlevelError
+// UnimplError : LowlevelError
+//
+// IfaceError (interface.hh)
+// IfaceExecutionError : IfaceError
+// IfaceParseError : IfaceError
+//
+// DecoderError (xml.hh)
+
 namespace rust {
     namespace behavior {
         template <typename Try, typename Fail>

--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -7,7 +7,6 @@ use cxx::{let_cxx_string, UniquePtr};
 use crate::ffi::api;
 use crate::ffi::rust;
 use crate::ffi::sys;
-use crate::ffi::sys::AddrSpace;
 use crate::opcodes::OpCode;
 
 /// Tracks whether the one-time initialization required for libsla has been performed
@@ -593,7 +592,7 @@ impl GhidraSleigh {
         Default::default()
     }
 
-    fn sys_address_space(&self, space_id: AddressSpaceId) -> Option<*mut AddrSpace> {
+    fn sys_address_space(&self, space_id: AddressSpaceId) -> Option<*mut sys::AddrSpace> {
         let num_spaces = self.sleigh.num_spaces();
         for i in 0..num_spaces {
             let addr_space = self.sleigh.address_space(i);


### PR DESCRIPTION
Updated the main README and the libsla README to point to the new sleigh compiler. Also included some miscellaneous cleanup for the 0.3.1 libsla release.