### PR TITLE
Add missing zlib files

### DIFF
--- a/crates/libsla-sys/Cargo.toml
+++ b/crates/libsla-sys/Cargo.toml
@@ -15,6 +15,7 @@ include = [
     "/build.rs",
     "/src/*",
     "/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",
+    "/ghidra/Ghidra/Features/Decompiler/src/decompile/zlib/*",
     "/ghidra/DISCLAIMER.md",
     "/ghidra/NOTICE",
     "/ghidra/LICENSE",

--- a/crates/libsla-sys/README.md
+++ b/crates/libsla-sys/README.md
@@ -1,0 +1,1 @@
+This is a system crate that exposes direct bindings to the Ghidra Sleigh library `libsla.a`. See the [libsla](https://crates.io/crates/libsla) crate for interfacing with Sleigh from Rust.


### PR DESCRIPTION
The libsla-sys crate needs zlib files due to the new binary format. These were built but not published in `Cargo.toml`, which caused publishing to fail.