### PR TITLE
Add rustfmt check to github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,8 @@ jobs:
         submodules: recursive
     - name: Build
       run: cargo build --verbose --all-targets
+    - name: Format
+      run: cargo fmt --all -- --check
     - name: Add test fixture targets
       run: |
         rustup target add x86_64-unknown-none

--- a/crates/pcode/src/arch/x86/emulator.rs
+++ b/crates/pcode/src/arch/x86/emulator.rs
@@ -89,7 +89,7 @@ impl<S: Sleigh, K: Kernel> PcodeEmulator for EmulatorX86<S, K> {
                     // This should be made more generic around x86 and then support supplying
                     // different kernels instead of treating this as a Linux emulator specifically
                     Some(x) if x == CallOtherOps::SysCall as u64 => {
-                        return self.kernel.syscall(self.sleigh.as_ref(), memory)
+                        return self.kernel.syscall(self.sleigh.as_ref(), memory);
                     }
                     Some(x) if x == CallOtherOps::Lock as u64 => {
                         // Lock instruction. Multithreading not supported so just ignore

--- a/crates/pcode/src/emulator.rs
+++ b/crates/pcode/src/emulator.rs
@@ -38,7 +38,9 @@ pub enum Error {
     /// No address space with the given identifier is associated with this emulator. This can occur
     /// if the instruction was decoded with a different set of address spaces than the ones
     /// registered with this emulator.
-    #[error("unknown address space id {space_id} referenced by {varnode} in instruction: {instruction:?}")]
+    #[error(
+        "unknown address space id {space_id} referenced by {varnode} in instruction: {instruction:?}"
+    )]
     UnknownAddressSpace {
         instruction: Box<PcodeInstruction>,
         varnode: VarnodeData,
@@ -274,7 +276,7 @@ impl PcodeEmulator for StandardPcodeEmulator {
             _ => {
                 return Err(Error::UnsupportedInstruction {
                     instruction: Box::new(instruction.clone()),
-                })
+                });
             }
         }
 

--- a/crates/pcode/src/kernel/linux.rs
+++ b/crates/pcode/src/kernel/linux.rs
@@ -341,7 +341,7 @@ impl LinuxKernel {
             _ => {
                 return Err(Error::UnhandledSyscall {
                     syscall_num: Syscall::ArchPrctl as u32,
-                })
+                });
             }
         }
 

--- a/crates/sym/src/convert.rs
+++ b/crates/sym/src/convert.rs
@@ -261,7 +261,7 @@ where
             _ => {
                 return Err(ConcretizationError::NonLiteralBit {
                     bit_index: 8 * byte_index + bit_index,
-                })
+                });
             }
         };
 

--- a/crates/sym/src/sym.rs
+++ b/crates/sym/src/sym.rs
@@ -76,7 +76,7 @@ impl std::ops::BitAnd for SymbolicBit {
             SymbolicBit::Literal(true) => return rhs,
             SymbolicBit::Variable(x) => match rhs {
                 SymbolicBit::Not(y) if *y == SymbolicBit::Variable(x) => {
-                    return SymbolicBit::Literal(false)
+                    return SymbolicBit::Literal(false);
                 }
                 _ => (),
             },
@@ -88,7 +88,7 @@ impl std::ops::BitAnd for SymbolicBit {
             SymbolicBit::Literal(true) => return self,
             SymbolicBit::Variable(x) => match self {
                 SymbolicBit::Not(y) if *y == SymbolicBit::Variable(x) => {
-                    return SymbolicBit::Literal(false)
+                    return SymbolicBit::Literal(false);
                 }
                 _ => (),
             },


### PR DESCRIPTION
This adds a check for appropriate formatting to the workflow. This change also cleans up some formatting via `cargo fmt`.