### PR TITLE
Upgrade Rust edition from 2021 to 2024

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "benches", "tests"]
 
 [workspace.package]
 authors = ["mnemonikr"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/mnemonikr/symbolic-pcode"
 

--- a/benches/emulator.rs
+++ b/benches/emulator.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use libsla::{
     Address, AddressSpace, AddressSpaceId, AddressSpaceType, BoolOp, IntOp, IntSign, OpCode,
     PcodeInstruction, VarnodeData,

--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Once;
 
-use libsla_sys::cxx::{let_cxx_string, CxxVector, UniquePtr};
+use libsla_sys::cxx::{CxxVector, UniquePtr, let_cxx_string};
 
 use crate::opcodes::OpCode;
 use libsla_sys::api;

--- a/crates/pcode-ops/src/validate.rs
+++ b/crates/pcode-ops/src/validate.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use crate::convert::PcodeValue;
 use crate::PcodeOps;
+use crate::convert::PcodeValue;
 
 /// Error returned when validation fails
 #[derive(Debug)]

--- a/crates/pcode/src/arch/x86/processor.rs
+++ b/crates/pcode/src/arch/x86/processor.rs
@@ -2,7 +2,7 @@ use libsla::{Address, AddressSpace, Sleigh, VarnodeData};
 
 use crate::mem::VarnodeDataStore;
 use crate::processor::{Error, PcodeExecution, ProcessorResponseHandler, Result};
-use pcode_ops::{convert::PcodeValue, PcodeOps};
+use pcode_ops::{PcodeOps, convert::PcodeValue};
 
 #[derive(Debug, Clone)]
 pub struct ProcessorHandlerX86 {

--- a/crates/pcode/src/emulator.rs
+++ b/crates/pcode/src/emulator.rs
@@ -2,7 +2,7 @@ use libsla::{
     Address, AddressSpace, AddressSpaceId, AddressSpaceType, BoolOp, IntOp, IntSign, OpCode,
     PcodeInstruction, VarnodeData,
 };
-use pcode_ops::{convert::PcodeValue, BitwisePcodeOps, PcodeOps};
+use pcode_ops::{BitwisePcodeOps, PcodeOps, convert::PcodeValue};
 use thiserror;
 
 use crate::mem::{self, VarnodeDataStore};

--- a/crates/pcode/src/kernel/linux.rs
+++ b/crates/pcode/src/kernel/linux.rs
@@ -4,8 +4,8 @@ use crate::emulator::{self, ControlFlow};
 use crate::kernel::Kernel;
 use crate::mem::VarnodeDataStore;
 use libsla::{Address, Sleigh, VarnodeData};
-use pcode_ops::convert::{PcodeValue, TryFromPcodeValueError};
 use pcode_ops::PcodeOps;
+use pcode_ops::convert::{PcodeValue, TryFromPcodeValueError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/crates/pcode/src/mem.rs
+++ b/crates/pcode/src/mem.rs
@@ -403,11 +403,7 @@ impl<'b, 'd, M: VarnodeDataStore + Default> MemoryTree<'b, 'd, M> {
                 // Must check first argument first since it is the accumulator
                 // If an error is propagating it will propagate here.
                 if let Ok(x) = x {
-                    if let Ok(y) = y {
-                        Ok(x.and(y))
-                    } else {
-                        y
-                    }
+                    if let Ok(y) = y { Ok(x.and(y)) } else { y }
                 } else {
                     x
                 }

--- a/crates/pcode/src/processor.rs
+++ b/crates/pcode/src/processor.rs
@@ -76,11 +76,8 @@ pub struct Processor<
     emulator: E,
 }
 
-impl<
-        E: PcodeEmulator + Clone,
-        M: VarnodeDataStore + Default,
-        H: ProcessorResponseHandler + Clone,
-    > Processor<E, M, H>
+impl<E: PcodeEmulator + Clone, M: VarnodeDataStore + Default, H: ProcessorResponseHandler + Clone>
+    Processor<E, M, H>
 {
     pub fn new(memory: M, emulator: E, handler: H) -> Self {
         Self {
@@ -204,11 +201,8 @@ pub struct BranchingProcessor<
     processor: Processor<E, MemoryBranch<M>, H>,
 }
 
-impl<
-        E: PcodeEmulator + Clone,
-        M: VarnodeDataStore + Default,
-        H: ProcessorResponseHandler + Clone,
-    > BranchingProcessor<E, M, H>
+impl<E: PcodeEmulator + Clone, M: VarnodeDataStore + Default, H: ProcessorResponseHandler + Clone>
+    BranchingProcessor<E, M, H>
 {
     pub fn new(memory: M, emulator: E, handler: H) -> Self {
         Self {

--- a/crates/sym/src/aiger.rs
+++ b/crates/sym/src/aiger.rs
@@ -203,7 +203,7 @@ impl AigerGate {
     /// `rhs.0 - rhs.1` are LEB128 encoded. Note that `rhs` literals may be internally swapped to
     /// ensure that `rhs.0 > rhs.1`
     pub fn serialize_binary(&self) -> Vec<u8> {
-        let deltas = (self.lhs.0 - self.rhs.0 .0, self.rhs.0 .0 - self.rhs.1 .0);
+        let deltas = (self.lhs.0 - self.rhs.0.0, self.rhs.0.0 - self.rhs.1.0);
         let mut encodings = ([0u8; Self::max_leb_size()], [0u8; Self::max_leb_size()]);
         let lens = (
             Self::leb128_encode(deltas.0, &mut encodings.0),

--- a/crates/sym/src/lib.rs
+++ b/crates/sym/src/lib.rs
@@ -6,9 +6,9 @@ mod pcode;
 mod sym;
 
 pub use crate::buf::*;
+pub use crate::convert::ConcreteValue;
 pub use crate::convert::concretize;
 pub use crate::convert::concretize_into;
-pub use crate::convert::ConcreteValue;
 pub use crate::eval::*;
 pub use crate::sym::*;
 

--- a/crates/sym/src/tests/aiger.rs
+++ b/crates/sym/src/tests/aiger.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
-use crate::aiger::*;
 use crate::SymbolicBit;
+use crate::aiger::*;
 
 #[test]
 fn true_and_false_are_const() {

--- a/crates/sym/src/tests/bitbuf.rs
+++ b/crates/sym/src/tests/bitbuf.rs
@@ -1,4 +1,4 @@
-use crate::{SymbolicBitBuf, FALSE, TRUE};
+use crate::{FALSE, SymbolicBitBuf, TRUE};
 
 #[test]
 fn ops_not() {

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -2,9 +2,9 @@ mod common;
 
 use std::{path::Path, rc::Rc};
 
-use common::{x86_64_sleigh, Memory, TracingEmulator};
+use common::{Memory, TracingEmulator, x86_64_sleigh};
 use libsla::{Address, GhidraSleigh, Sleigh, VarnodeData};
-use pcode_ops::{convert::PcodeValue, PcodeOps};
+use pcode_ops::{PcodeOps, convert::PcodeValue};
 use sym::{self, Evaluator, SymbolicBit, SymbolicBitVec, SymbolicByte, VariableAssignments};
 use symbolic_pcode::{
     arch::x86::{emulator::EmulatorX86, processor::ProcessorHandlerX86},
@@ -77,9 +77,9 @@ fn initialize_libc_stack(memory: &mut Memory, sleigh: &impl Sleigh) {
 }
 
 fn memory_with_image(sleigh: &GhidraSleigh, image: impl AsRef<Path>) -> Memory {
+    use elf::ElfBytes;
     use elf::abi::PT_LOAD;
     use elf::endian::AnyEndian;
-    use elf::ElfBytes;
 
     let mut memory = Memory::default();
 


### PR DESCRIPTION
All changes are due to the formatting changes from the new style edition. No manual code changes or automated fixes outside of `cargo fmt` were made as a part of this.