### PR TITLE
Expanded Linux kernel model to support multiple architectures, AArch64 demo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
       run: |
         rustup target add x86_64-unknown-none
         rustup target add x86_64-unknown-linux-musl
+        rustup target add aarch64-unknown-none
+        rustup target add aarch64-unknown-linux-musl
     - name: Unit Tests
       run: cargo test --workspace --verbose
     - name: Coverage Report

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
         rustup target add x86_64-unknown-linux-musl
         rustup target add aarch64-unknown-none
         rustup target add aarch64-unknown-linux-musl
+    - name: Install aarch64 cross-compiler
+      run: sudo apt install -y gcc-aarch64-linux-gnu
     - name: Unit Tests
       run: cargo test --workspace --verbose
     - name: Coverage Report

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/mnemonikr/symbolic-pcode"
 
 [workspace.dependencies]
 thiserror = "2.0"
+log = "0.4"

--- a/crates/pcode/Cargo.toml
+++ b/crates/pcode/Cargo.toml
@@ -12,3 +12,4 @@ repository.workspace = true
 libsla = { path = "../libsla" }
 pcode-ops = { path = "../pcode-ops" }
 thiserror.workspace = true
+log.workspace = true

--- a/crates/pcode/src/arch.rs
+++ b/crates/pcode/src/arch.rs
@@ -1,1 +1,2 @@
+pub mod aarch64;
 pub mod x86;

--- a/crates/pcode/src/arch/aarch64.rs
+++ b/crates/pcode/src/arch/aarch64.rs
@@ -1,0 +1,3 @@
+pub mod emulator;
+pub mod linux;
+pub mod processor;

--- a/crates/pcode/src/arch/aarch64/emulator.rs
+++ b/crates/pcode/src/arch/aarch64/emulator.rs
@@ -1,0 +1,163 @@
+use std::rc::Rc;
+
+use libsla::{OpCode, PcodeInstruction, PseudoOp, Sleigh};
+use pcode_ops::PcodeOps;
+use pcode_ops::convert::{PcodeValue, TryFromPcodeValueError};
+
+use crate::emulator::{ControlFlow, Error, PcodeEmulator, Result, StandardPcodeEmulator};
+use crate::kernel::{Kernel, NoKernel};
+use crate::mem::VarnodeDataStore;
+
+#[repr(u64)]
+enum CallOtherOps {
+    SupervisorCall = 0x19,
+    DataMemoryBarrier = 0x1f,
+    ExclusiveMonitorPass = 0x3f,
+    ExclusiveMonitorsStatus = 0x40,
+}
+
+#[derive(Debug)]
+pub struct Emulator<S, K = NoKernel>
+where
+    S: Sleigh,
+    K: Kernel,
+{
+    sleigh: Rc<S>,
+    kernel: K,
+    emulator: StandardPcodeEmulator,
+}
+
+impl<S: Sleigh, K: Kernel + Clone> Clone for Emulator<S, K> {
+    fn clone(&self) -> Self {
+        Self {
+            sleigh: self.sleigh.clone(),
+            kernel: self.kernel.clone(),
+            emulator: self.emulator.clone(),
+        }
+    }
+}
+
+impl<S: Sleigh> Emulator<S, NoKernel> {
+    /// Create an emulator without a kernel. Syscalls will trigger [Error::UnsupportedInstruction].
+    pub fn without_kernel(sleigh: Rc<S>) -> Self {
+        Self {
+            emulator: StandardPcodeEmulator::new(sleigh.address_spaces()),
+            kernel: Default::default(),
+            sleigh,
+        }
+    }
+}
+
+impl<S: Sleigh, K: Kernel> Emulator<S, K> {
+    /// Create an emulator with syscalls implemented by the given kernel
+    pub fn with_kernel(sleigh: Rc<S>, kernel: K) -> Self {
+        Self {
+            emulator: StandardPcodeEmulator::new(sleigh.address_spaces()),
+            kernel,
+            sleigh,
+        }
+    }
+
+    /// Get a reference to the kernel
+    pub fn kernel(&self) -> &K {
+        &self.kernel
+    }
+}
+
+impl<S: Sleigh, K: Kernel> PcodeEmulator for Emulator<S, K> {
+    fn emulate<M: VarnodeDataStore>(
+        &mut self,
+        memory: &mut M,
+        instruction: &PcodeInstruction,
+    ) -> Result<ControlFlow> {
+        println!("Executing: {instruction}");
+        for instr_input in instruction.inputs.iter() {
+            let input = PcodeValue::from(memory.read(instr_input).unwrap());
+            match u128::try_from(input) {
+                Ok(value) => {
+                    println!(
+                        "Input {instr_input} = {value:0width$x}",
+                        width = 2 * instr_input.size
+                    );
+                }
+                Err(TryFromPcodeValueError::InvalidSize) => {
+                    println!("Input {instr_input} = Large value")
+                }
+                Err(TryFromPcodeValueError::InvalidByte { index }) => {
+                    println!("Input {instr_input} = Symbolic value @ {index}")
+                }
+            }
+        }
+        let result = self.emulator.emulate(memory, instruction);
+
+        if let Err(Error::UnsupportedInstruction { instruction }) = &result {
+            if instruction.op_code == OpCode::Pseudo(PseudoOp::CallOther) {
+                let arg = instruction.inputs.first().and_then(|input| {
+                    if input.address.address_space.is_constant() {
+                        Some(input.address.offset)
+                    } else {
+                        None
+                    }
+                });
+
+                match arg {
+                    Some(x) if x == CallOtherOps::SupervisorCall as u64 => {
+                        return self.kernel.syscall(self.sleigh.as_ref(), memory);
+                    }
+                    Some(x) if x == CallOtherOps::ExclusiveMonitorPass as u64 => {
+                        if let Some(output) = instruction.output.as_ref() {
+                            // 1 Indicates that the monitor passes and the register can be written
+                            // See usage in AARCH64base.sinc
+                            memory.write(output, M::Value::from_le(1u8))?;
+                        }
+                        return Ok(ControlFlow::NextInstruction);
+                    }
+                    Some(x) if x == CallOtherOps::ExclusiveMonitorsStatus as u64 => {
+                        if let Some(output) = instruction.output.as_ref() {
+                            // 0 on success
+                            // See usage in AARCH64base.sinc
+                            memory.write(output, M::Value::from_le(0u8))?;
+                        }
+                        return Ok(ControlFlow::NextInstruction);
+                    }
+                    Some(x) if x == CallOtherOps::DataMemoryBarrier as u64 => {
+                        return Ok(ControlFlow::NextInstruction);
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        if result.is_ok() {
+            match &instruction.op_code {
+                OpCode::Store => println!("Store"),
+                OpCode::Branch
+                | OpCode::BranchIndirect
+                | OpCode::BranchConditional
+                | OpCode::Call
+                | OpCode::CallIndirect
+                | OpCode::Return => {
+                    println!("Branch: {result:?}")
+                }
+                OpCode::Pseudo(x) => {
+                    println!("PseudoCall: {x:?}")
+                }
+                _ => {
+                    let output_result = memory.read(instruction.output.as_ref().unwrap()).unwrap();
+                    let output = PcodeValue::from(output_result);
+                    let output: std::result::Result<u128, _> = output.try_into();
+                    if let Ok(output) = output {
+                        println!(
+                            "Output: {output:0width$x}",
+                            width = 2 * instruction.output.as_ref().unwrap().size
+                        );
+                    } else {
+                        println!("Output: Symbolic");
+                    }
+                }
+            }
+        }
+
+        result
+    }
+}

--- a/crates/pcode/src/arch/aarch64/linux.rs
+++ b/crates/pcode/src/arch/aarch64/linux.rs
@@ -1,0 +1,33 @@
+use crate::kernel::linux::{LinuxArchConfig, Syscall};
+
+pub fn config() -> LinuxArchConfig {
+    LinuxArchConfig {
+        syscall_num_register: "w8".to_owned(),
+        arg_registers: [
+            "x0".to_owned(),
+            "x1".to_owned(),
+            "x2".to_owned(),
+            "x3".to_owned(),
+            "x4".to_owned(),
+            "x5".to_owned(),
+        ],
+        return_register: "x0".to_owned(),
+        // https://github.com/torvalds/linux/blob/v6.16/arch/arm64/tools/syscall_64.tbl
+        // https://github.com/torvalds/linux/blob/v6.16/scripts/syscall.tbl
+        syscall_map: [
+            (96, Syscall::SetTidAddress),
+            (73, Syscall::Ppoll),
+            (134, Syscall::RtSigAction),
+            (132, Syscall::SigAltStack),
+            (222, Syscall::Mmap),
+            (226, Syscall::Mprotect),
+            (135, Syscall::RtSigProcMask),
+            (214, Syscall::Brk),
+            (64, Syscall::Write),
+            (215, Syscall::Munmap),
+            (94, Syscall::ExitGroup),
+        ]
+        .into_iter()
+        .collect(),
+    }
+}

--- a/crates/pcode/src/arch/aarch64/processor.rs
+++ b/crates/pcode/src/arch/aarch64/processor.rs
@@ -1,0 +1,71 @@
+use libsla::{Address, AddressSpace, Sleigh, VarnodeData};
+
+use crate::mem::VarnodeDataStore;
+use crate::processor::{Error, PcodeExecution, ProcessorResponseHandler, Result};
+use pcode_ops::{PcodeOps, convert::PcodeValue};
+
+#[derive(Debug, Clone)]
+pub struct ProcessorHandler {
+    pc: VarnodeData,
+    instruction_address_space: AddressSpace,
+}
+
+impl ProcessorHandler {
+    pub fn new(sleigh: &impl Sleigh) -> Self {
+        let pc = sleigh
+            .register_from_name("pc")
+            .expect("failed to get pc register");
+        let instruction_address_space = sleigh.default_code_space();
+        Self {
+            pc,
+            instruction_address_space,
+        }
+    }
+}
+
+impl ProcessorResponseHandler for ProcessorHandler {
+    fn fetched<M: VarnodeDataStore>(&mut self, memory: &mut M) -> Result<Address> {
+        let offset = PcodeValue::from(memory.read(&self.pc)?)
+            .try_into()
+            .map_err(|err| {
+                Error::InternalError(format!(
+                    "failed to convert instruction to concrete address: {err:?}"
+                ))
+            })?;
+        Ok(Address::new(self.instruction_address_space.clone(), offset))
+    }
+
+    fn decoded<M: VarnodeDataStore>(
+        &mut self,
+        memory: &mut M,
+        execution: &PcodeExecution,
+    ) -> Result<()> {
+        let pc_value: u64 = PcodeValue::from(memory.read(&self.pc)?)
+            .try_into()
+            .map_err(|err| {
+                Error::InternalError(format!(
+                    "failed to convert instruction to concrete address: {err:?}"
+                ))
+            })?;
+        let bytes_read = u64::try_from(execution.origin().size).map_err(|err| {
+            Error::InternalError(format!(
+                "RIP value {pc_value:016x} failed to convert to u64: {err}",
+            ))
+        })?;
+        let pc_value = pc_value.checked_add(bytes_read).ok_or_else(|| {
+            Error::InternalError(format!(
+                "RIP {pc_value:016x} + {len} overflowed",
+                len = execution.origin().size
+            ))
+        })?;
+
+        memory.write(&self.pc, M::Value::from_le(pc_value))?;
+
+        Ok(())
+    }
+
+    fn jumped<M: VarnodeDataStore>(&mut self, memory: &mut M, address: &Address) -> Result<()> {
+        memory.write(&self.pc, M::Value::from_le(address.offset))?;
+        Ok(())
+    }
+}

--- a/crates/pcode/src/processor.rs
+++ b/crates/pcode/src/processor.rs
@@ -342,6 +342,10 @@ impl PcodeExecution {
         Self { pcode, index: 0 }
     }
 
+    pub fn pcode(&self) -> &Disassembly<PcodeInstruction> {
+        &self.pcode
+    }
+
     pub fn origin(&self) -> &VarnodeData {
         &self.pcode.origin
     }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,6 +15,7 @@ pcode-ops = { path = "../crates/pcode-ops" }
 sym = { path = "../crates/sym" }
 
 [dev-dependencies]
+flexi_logger = "0.31"
 elf = "0.8"
 sleigh-compiler = "2.0"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -36,3 +36,7 @@ path = "x86_64_emulator.rs"
 [[test]]
 name = "sleigh"
 path = "sleigh.rs"
+
+[[test]]
+name = "hello_world"
+path = "hello_world.rs"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,16 +1,29 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::{collections::BTreeMap, fs};
 
 use libsla::{Address, AddressSpace, GhidraSleigh, OpCode, PcodeInstruction, Sleigh, VarnodeData};
 use pcode_ops::convert::PcodeValue;
-use sym::SymbolicBitVec;
+use sym::{SymbolicBit, SymbolicBitVec, SymbolicByte};
 use symbolic_pcode::emulator::{self, ControlFlow, PcodeEmulator, StandardPcodeEmulator};
 use symbolic_pcode::mem::{GenericMemory, MemoryBranch, VarnodeDataStore};
 use symbolic_pcode::processor::{self, PcodeExecution, ProcessorResponseHandler};
 
 static X86_64_SLA: OnceLock<PathBuf> = OnceLock::new();
 static AARCH_64_SLA: OnceLock<PathBuf> = OnceLock::new();
+static LOGGER_INIT: OnceLock<flexi_logger::LoggerHandle> = OnceLock::new();
+
+pub fn initialize_logger() -> &'static flexi_logger::LoggerHandle {
+    LOGGER_INIT.get_or_init(|| {
+        flexi_logger::Logger::try_with_env()
+            .unwrap()
+            .start()
+            .unwrap()
+    })
+}
+
+pub const INITIAL_STACK: u64 = 0x8000000000;
+pub const EXIT_IP_ADDR: u64 = 0xFEEDBEEF0BADF00D;
 
 pub type Memory = GenericMemory<SymbolicBitVec>;
 
@@ -165,4 +178,293 @@ pub fn aarch64_sleigh() -> libsla::Result<GhidraSleigh> {
         .processor_spec(&processor_spec)?
         .build()?;
     Ok(sleigh)
+}
+
+pub fn initialize_libc_stack(memory: &mut Memory, sleigh: &impl Sleigh) {
+    // The stack for libc programs:
+    // * argc
+    // * argv - list must be terminated by NULL pointer
+    // * envp - list must be terminated by NULL pointer
+    // * auxv - list must be terminated by NULL pointer
+    let ram = sleigh
+        .address_space_by_name("ram")
+        .expect("failed to find ram");
+    let argc = VarnodeData {
+        address: Address {
+            offset: INITIAL_STACK,
+            address_space: ram.clone(),
+        },
+        size: 8,
+    };
+    memory
+        .write(&argc, SymbolicBitVec::constant(1, u64::BITS as usize))
+        .expect("failed to initialize argc on stack");
+
+    // The argv list must be terminated by null pointer. Setting program name to null AND
+    // terminating the list with NULL, whence 16 bytes
+    //
+    // MUSL has support for null program name:
+    // https://git.musl-libc.org/cgit/musl/tree/src/env/__libc_start_main.c
+    let argv = VarnodeData {
+        address: Address {
+            offset: argc.address.offset + argc.size as u64,
+            address_space: ram.clone(),
+        },
+        size: 16,
+    };
+    memory
+        .write(&argv, SymbolicBitVec::constant(0, (2 * u64::BITS) as usize))
+        .expect("failed to initialize argv");
+
+    let envp = VarnodeData {
+        address: Address {
+            offset: argv.address.offset + argv.size as u64,
+            address_space: ram.clone(),
+        },
+        size: 8,
+    };
+    memory
+        .write(&envp, SymbolicBitVec::constant(0, u64::BITS as usize))
+        .expect("failed to initialize envp");
+
+    // MUSL targets initialize the libc pagesize using aux[AT_PAGESZ]. For architectures without a
+    // hardcoded value the libc pagesize is used. For example x86-64 has a hardcoded value of 4096
+    // and so this is ignored. However for aarch64 there is no hardcoded value. This must be
+    // supplied otherwise a pagesize of 0 will be used.
+    let mut auxv = VarnodeData {
+        address: Address {
+            offset: envp.address.offset + envp.size as u64,
+            address_space: ram.clone(),
+        },
+        size: 8,
+    };
+
+    // The index for AT_PAGESZ
+    let at_pagesz = 6;
+    memory
+        .write(
+            &auxv,
+            SymbolicBitVec::constant(at_pagesz, u64::BITS as usize),
+        )
+        .expect("failed to write AT_PAGESZ into auxv");
+    auxv.address.offset += auxv.size as u64;
+
+    let page_size = 4096;
+    memory
+        .write(
+            &auxv,
+            SymbolicBitVec::constant(page_size, u64::BITS as usize),
+        )
+        .expect("failed to write page size into auxv");
+    auxv.address.offset += auxv.size as u64;
+
+    memory
+        .write(&auxv, SymbolicBitVec::constant(0, u64::BITS as usize))
+        .expect("failed to initialize auxv");
+}
+
+pub fn memory_with_image(
+    sleigh: &GhidraSleigh,
+    image: impl AsRef<Path>,
+    pc_register: &VarnodeData,
+) -> Memory {
+    use elf::ElfBytes;
+    use elf::abi::PT_LOAD;
+    use elf::endian::AnyEndian;
+
+    let mut memory = Memory::default();
+
+    // Write image into memory
+    let data = std::fs::read(image).expect("failed to read image file");
+
+    let elf = ElfBytes::<AnyEndian>::minimal_parse(&data).expect("failed to parse elf");
+    for segment in elf.segments().expect("failed to get segments") {
+        if segment.p_type != PT_LOAD {
+            // Not a loadable segment
+            continue;
+        }
+
+        let data_location = VarnodeData {
+            address: Address {
+                offset: segment.p_vaddr,
+                address_space: sleigh.default_code_space(),
+            },
+
+            // The initial set of data is from the file
+            size: segment.p_filesz as usize,
+        };
+
+        // Write the segment from the file into memory
+        let offset = segment.p_offset as usize;
+        let file_size = segment.p_filesz as usize;
+        memory
+            .write(
+                &data_location,
+                data[offset..offset + file_size].iter().copied().collect(),
+            )
+            .expect("failed to write image section into memory");
+
+        println!(
+            "Loaded segment {vaddr:#x} from {offset:#x} ({file_size})",
+            vaddr = segment.p_vaddr
+        );
+
+        // If the virtual size is larger than the file size then zero out the remainder
+        let zero_size = (segment.p_memsz - segment.p_filesz) as usize;
+        if zero_size > 0 {
+            let zeros = vec![0u8; zero_size];
+            let zeros_location = VarnodeData {
+                address: Address {
+                    offset: segment.p_vaddr + segment.p_filesz,
+                    address_space: sleigh.default_code_space(),
+                },
+                size: zero_size,
+            };
+            println!(
+                "Zeroing segment {vaddr:#x} at {zeros_location}",
+                vaddr = segment.p_vaddr
+            );
+            memory
+                .write(&zeros_location, zeros.into_iter().collect())
+                .expect("failed to write zeros into memory");
+        }
+    }
+
+    // Init RIP to entry
+    memory
+        .write(pc_register, elf.ehdr.e_entry.into())
+        .expect("failed to initialize PC register");
+
+    memory
+}
+
+pub fn init_registers_x86_64(sleigh: &impl Sleigh, memory: &mut Memory) {
+    let rsp = sleigh.register_from_name("RSP").expect("invalid register");
+    let registers = ["RAX", "RBX", "RCX", "RDX", "RSI", "RDI", "RBP"]
+        .into_iter()
+        .map(str::to_owned)
+        .chain((8..16).map(|n| format!("R{n}")));
+
+    init_registers(sleigh, memory, &rsp, registers);
+
+    // Initialize the DF register to 0. It appears to be a convention that whenever STD is called
+    // CLD is called thereafter to reset it. There is a bug (?) in MUSL where REP STOS is used
+    // without ensuring the flag is cleared
+
+    // 0000000000449f4d <__init_libc>:
+    //   449f4d:       53                      push   rbx
+    //   449f4e:       48 89 fa                mov    rdx,rdi
+    //   449f51:       31 c0                   xor    eax,eax
+    //   449f53:       b9 4c 00 00 00          mov    ecx,0x4c
+    //   449f58:       48 81 ec 50 01 00 00    sub    rsp,0x150
+    //   449f5f:       48 8d 7c 24 20          lea    rdi,[rsp+0x20]
+    //   449f64:       f3 ab                   rep stos DWORD PTR es:[rdi],eax
+
+    let df_register = sleigh
+        .register_from_name("DF")
+        .expect("failed to get DF register");
+    memory
+        .write(&df_register, 0u8.into())
+        .expect("failed to init DF register");
+}
+
+pub fn init_registers_aarch64(sleigh: &impl Sleigh, memory: &mut Memory) {
+    let sp = sleigh
+        .register_from_name("sp")
+        .expect("invalid stack register");
+    let registers = (0..30).map(|n| format!("x{n}"));
+
+    init_registers(sleigh, memory, &sp, registers);
+
+    // Init link register value to final return address
+    let link_register = sleigh
+        .register_from_name("x30")
+        .expect("invalid link register");
+    memory
+        .write(&link_register, EXIT_IP_ADDR.into())
+        .expect("failed to initialize link register");
+
+    // Initialize system register `dczid_el0`
+    //
+    // Per DDI0487L_b_a-profile_architecture_reference_manual.pdf
+    //
+    // Indicates the block size that is written with byte values of 0 by the DC ZVA (Data Cache
+    // Zero by Address) System instruction.
+    //
+    // - Bits [63:5] Reserved, RES0.
+    // - Bit [4] Data Zero Prohibited (DZP). This field indicates whether the use of `DC ZVA`
+    // instruction is permitted (0b0) or prohibited (0b1).
+    // - Bits [3:0] Block Size (BS). Log2 of the block size in words.
+    let dczid_el0 = sleigh
+        .register_from_name("dczid_el0")
+        .expect("unknown register");
+    memory
+        .write(&dczid_el0, 0x10u64.into())
+        .expect("failed to initialize dczid_el0");
+}
+
+fn init_registers(
+    sleigh: &impl Sleigh,
+    memory: &mut Memory,
+    stack_register: &VarnodeData,
+    registers: impl IntoIterator<Item = String>,
+) {
+    let mut bitvar = 0;
+    for register_name in registers.into_iter() {
+        let mut bytes = Vec::with_capacity(8);
+        for _ in 0..8 {
+            let byte: SymbolicByte = [
+                SymbolicBit::Variable(bitvar),
+                SymbolicBit::Variable(bitvar + 1),
+                SymbolicBit::Variable(bitvar + 2),
+                SymbolicBit::Variable(bitvar + 3),
+                SymbolicBit::Variable(bitvar + 4),
+                SymbolicBit::Variable(bitvar + 5),
+                SymbolicBit::Variable(bitvar + 6),
+                SymbolicBit::Variable(bitvar + 7),
+            ]
+            .into();
+            bytes.push(byte);
+            bitvar += 8;
+        }
+
+        let register = sleigh
+            .register_from_name(&register_name)
+            .unwrap_or_else(|err| panic!("invalid register {register_name}: {err}"));
+        memory
+            .write(&register, bytes.into_iter().collect())
+            .unwrap_or_else(|err| panic!("failed to write register {register_name}: {err}"));
+    }
+
+    // Init stack register to stack address
+    memory
+        .write(stack_register, INITIAL_STACK.into())
+        .expect("failed to initialize stack register");
+}
+
+pub fn find_test_fixture(
+    messages: escargot::CommandMessages,
+) -> Result<std::path::PathBuf, Vec<escargot::error::CargoResult<escargot::Message>>> {
+    let messages: Vec<_> = messages.into_iter().collect();
+    let executable_path = messages.iter().find_map(|result| {
+        result
+            .as_ref()
+            .ok()
+            .into_iter()
+            .filter_map(|msg| {
+                msg.decode()
+                    .ok()
+                    .into_iter()
+                    .filter_map(|msg| match msg {
+                        escargot::format::Message::CompilerArtifact(artifact) => {
+                            artifact.executable.map(|p| p.into_owned())
+                        }
+                        _ => None,
+                    })
+                    .next()
+            })
+            .next()
+    });
+
+    executable_path.ok_or(messages)
 }

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -1,0 +1,152 @@
+mod common;
+
+use std::rc::Rc;
+
+use libsla::Sleigh;
+use pcode_ops::PcodeOps;
+use symbolic_pcode::arch;
+use symbolic_pcode::kernel::linux::LinuxKernel;
+use symbolic_pcode::mem::VarnodeDataStore;
+use symbolic_pcode::processor::{self, Processor, ProcessorState};
+
+#[test]
+fn hello_world_x86_linux() -> processor::Result<()> {
+    common::initialize_logger();
+
+    // Build test fixture first
+    let messages = escargot::CargoBuild::new()
+        .bin("linux-syscalls")
+        .manifest_path("./test-fixtures/linux-syscalls/Cargo.toml")
+        .target("x86_64-unknown-linux-musl")
+        .env(
+            "RUSTFLAGS",
+            "-Ctarget-feature=+crt-static -Crelocation-model=static",
+        )
+        .exec()
+        .unwrap();
+
+    let image = match common::find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
+    let sleigh = Rc::new(common::x86_64_sleigh().expect("failed to build sleigh"));
+    let rip = sleigh.register_from_name("RIP").expect("invalid register");
+    let mut memory = common::memory_with_image(&sleigh, image, &rip);
+    common::init_registers_x86_64(sleigh.as_ref(), &mut memory);
+    common::initialize_libc_stack(&mut memory, sleigh.as_ref());
+
+    let handler = arch::x86::processor::ProcessorHandlerX86::new(sleigh.as_ref());
+    let emulator =
+        arch::x86::emulator::EmulatorX86::with_kernel(sleigh.clone(), LinuxKernel::default());
+    let mut processor = Processor::new(memory, emulator, handler);
+
+    loop {
+        processor.step(sleigh.as_ref())?;
+
+        // Debug
+        if matches!(processor.state(), ProcessorState::Decode(_)) {
+            let disassembly = processor.disassemble(sleigh.as_ref())?;
+            let encoded_instr = processor
+                .memory()
+                .read(&disassembly.origin)?
+                .into_le_bytes()
+                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            println!("Encoded instruction from memory: {encoded_instr}");
+            println!("Decoded: {disassembly}");
+        }
+
+        if matches!(processor.state(), ProcessorState::Halt) {
+            assert_eq!(
+                processor.emulator().kernel().exit_status(),
+                Some(0),
+                "exit code should be 0"
+            );
+            return Ok(());
+        }
+    }
+}
+
+#[test]
+fn hello_world_aarch64_linux() -> processor::Result<()> {
+    common::initialize_logger();
+
+    // Build test fixture first
+    let messages = escargot::CargoBuild::new()
+        .bin("linux-syscalls")
+        .manifest_path("./test-fixtures/linux-syscalls/Cargo.toml")
+        .target("aarch64-unknown-linux-musl")
+        .env(
+            "RUSTFLAGS",
+            "-Ctarget-feature=+crt-static -Crelocation-model=static",
+        )
+        // On Ubuntu can install with sudo apt install gcc-aarch64-linux-gnu
+        .env(
+            "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER",
+            "aarch64-linux-gnu-gcc",
+        )
+        .exec()
+        .unwrap();
+
+    let image = match common::find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
+    let sleigh = Rc::new(common::aarch64_sleigh().expect("failed to build sleigh"));
+    let pc = sleigh.register_from_name("pc").expect("invalid register");
+    let mut memory = common::memory_with_image(&sleigh, image, &pc);
+    common::init_registers_aarch64(sleigh.as_ref(), &mut memory);
+    common::initialize_libc_stack(&mut memory, sleigh.as_ref());
+
+    let handler = arch::aarch64::processor::ProcessorHandler::new(sleigh.as_ref());
+    let emulator = arch::aarch64::emulator::Emulator::with_kernel(
+        sleigh.clone(),
+        LinuxKernel::with_config(arch::aarch64::linux::config()),
+    );
+    let mut processor = Processor::new(memory, emulator, handler);
+
+    loop {
+        let print_pcode = matches!(processor.state(), ProcessorState::Decode(_));
+        processor.step(sleigh.as_ref())?;
+
+        if print_pcode {
+            if let ProcessorState::Execute(e) = processor.state() {
+                for instr in &e.pcode().instructions {
+                    println!("{instr}");
+                }
+            }
+        }
+
+        // Debug
+        if matches!(processor.state(), ProcessorState::Decode(_)) {
+            let disassembly = processor.disassemble(sleigh.as_ref())?;
+            let encoded_instr = processor
+                .memory()
+                .read(&disassembly.origin)?
+                .into_le_bytes()
+                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            println!("Encoded instruction from memory: {encoded_instr}");
+            println!("Decoded: {instr}", instr = disassembly.instructions[0]);
+        }
+
+        if matches!(processor.state(), ProcessorState::Halt) {
+            assert_eq!(
+                processor.emulator().kernel().exit_status(),
+                Some(0),
+                "exit code should be 0"
+            );
+            return Ok(());
+        }
+    }
+}

--- a/tests/test-fixtures/linux-syscalls/.cargo/config.toml
+++ b/tests/test-fixtures/linux-syscalls/.cargo/config.toml
@@ -1,3 +1,9 @@
+# This configuration file assumes this is being built on an x86-64 host platform.
+
 [build]
 target = ["x86_64-unknown-linux-musl"]
 rustflags = ["-Ctarget-feature=+crt-static", "-Crelocation-model=static"]
+
+# This can be installed on Ubuntu/Debian with apt package `gcc-aarch64-linux-gnu`
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"

--- a/tests/test-fixtures/pcode-coverage/src/arithmetic.rs
+++ b/tests/test-fixtures/pcode-coverage/src/arithmetic.rs
@@ -81,10 +81,17 @@ fn large_multiply(x: u128, y: u128) -> u128 {
 }
 
 #[inline(never)]
+#[cfg(target_arch = "x86_64")]
 fn negate(mut x: i64) -> i64 {
     // Required to force the neg instruction since the default assembly produced does not use it
     unsafe {
         core::arch::asm!("neg {x}", x = inout(reg) x);
     }
     x
+}
+
+#[inline(never)]
+#[cfg(not(target_arch = "x86_64"))]
+fn negate(x: i64) -> i64 {
+    -x
 }

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -7,15 +7,18 @@ use libsla::{Address, GhidraSleigh, Sleigh, VarnodeData};
 use pcode_ops::{PcodeOps, convert::PcodeValue};
 use sym::{self, Evaluator, SymbolicBit, SymbolicBitVec, SymbolicByte, VariableAssignments};
 use symbolic_pcode::{
-    arch::x86::{emulator::EmulatorX86, processor::ProcessorHandlerX86},
+    arch::{
+        self,
+        x86::{emulator::EmulatorX86, processor::ProcessorHandlerX86},
+    },
     emulator::StandardPcodeEmulator,
-    kernel::linux::LinuxKernel,
+    kernel::linux::{LinuxArchConfig, LinuxKernel},
     mem::{MemoryTree, VarnodeDataStore},
     processor::{self, BranchingProcessor, Processor, ProcessorState},
 };
 
 const INITIAL_STACK: u64 = 0x8000000000;
-const EXIT_RIP: u64 = 0xFEEDBEEF0BADF00D;
+const EXIT_IP_ADDR: u64 = 0xFEEDBEEF0BADF00D;
 
 fn initialize_libc_stack(memory: &mut Memory, sleigh: &impl Sleigh) {
     // The stack for libc programs:
@@ -64,19 +67,47 @@ fn initialize_libc_stack(memory: &mut Memory, sleigh: &impl Sleigh) {
         .write(&envp, SymbolicBitVec::constant(0, u64::BITS as usize))
         .expect("failed to initialize envp");
 
-    let auxv = VarnodeData {
+    // MUSL targets initialize the libc pagesize using aux[AT_PAGESZ]. For architectures without a
+    // hardcoded value the libc pagesize is used. For example x86-64 has a hardcoded value of 4096
+    // and so this is ignored. However for aarch64 there is no hardcoded value. This must be
+    // supplied otherwise a pagesize of 0 will be used.
+    let mut auxv = VarnodeData {
         address: Address {
             offset: envp.address.offset + envp.size as u64,
             address_space: ram.clone(),
         },
         size: 8,
     };
+
+    // The index for AT_PAGESZ
+    let at_pagesz = 6;
+    memory
+        .write(
+            &auxv,
+            SymbolicBitVec::constant(at_pagesz, u64::BITS as usize),
+        )
+        .expect("failed to write AT_PAGESZ into auxv");
+    auxv.address.offset += auxv.size as u64;
+
+    let page_size = 4096;
+    memory
+        .write(
+            &auxv,
+            SymbolicBitVec::constant(page_size, u64::BITS as usize),
+        )
+        .expect("failed to write page size into auxv");
+    auxv.address.offset += auxv.size as u64;
+
     memory
         .write(&auxv, SymbolicBitVec::constant(0, u64::BITS as usize))
-        .expect("failed to initialize envp");
+        .expect("failed to initialize auxv");
 }
 
-fn memory_with_image(sleigh: &GhidraSleigh, image: impl AsRef<Path>) -> Memory {
+fn memory_with_image(
+    sleigh: &GhidraSleigh,
+    image: impl AsRef<Path>,
+    pc_register: &VarnodeData,
+) -> Memory {
     use elf::ElfBytes;
     use elf::abi::PT_LOAD;
     use elf::endian::AnyEndian;
@@ -113,6 +144,11 @@ fn memory_with_image(sleigh: &GhidraSleigh, image: impl AsRef<Path>) -> Memory {
             )
             .expect("failed to write image section into memory");
 
+        println!(
+            "Loaded segment {vaddr:#x} from {offset:#x} ({file_size})",
+            vaddr = segment.p_vaddr
+        );
+
         // If the virtual size is larger than the file size then zero out the remainder
         let zero_size = (segment.p_memsz - segment.p_filesz) as usize;
         if zero_size > 0 {
@@ -124,6 +160,10 @@ fn memory_with_image(sleigh: &GhidraSleigh, image: impl AsRef<Path>) -> Memory {
                 },
                 size: zero_size,
             };
+            println!(
+                "Zeroing segment {vaddr:#x} at {zeros_location}",
+                vaddr = segment.p_vaddr
+            );
             memory
                 .write(&zeros_location, zeros.into_iter().collect())
                 .expect("failed to write zeros into memory");
@@ -131,23 +171,86 @@ fn memory_with_image(sleigh: &GhidraSleigh, image: impl AsRef<Path>) -> Memory {
     }
 
     // Init RIP to entry
-    let rip = sleigh.register_from_name("RIP").expect("invalid register");
     memory
-        .write(&rip, elf.ehdr.e_entry.into())
-        .expect("failed to initialize RIP");
+        .write(pc_register, elf.ehdr.e_entry.into())
+        .expect("failed to initialize PC register");
 
     memory
 }
 
-fn init_registers(sleigh: &impl Sleigh, memory: &mut Memory) {
-    let mut bitvar = 0;
+fn init_registers_x86_64(sleigh: &impl Sleigh, memory: &mut Memory) {
+    let rsp = sleigh.register_from_name("RSP").expect("invalid register");
     let registers = ["RAX", "RBX", "RCX", "RDX", "RSI", "RDI", "RBP"]
         .into_iter()
         .map(str::to_owned)
-        .chain((8..16).map(|n| format!("R{n}")))
-        .collect::<Vec<_>>();
+        .chain((8..16).map(|n| format!("R{n}")));
 
-    for register_name in registers {
+    init_registers(sleigh, memory, &rsp, registers);
+
+    // Initialize the DF register to 0. It appears to be a convention that whenever STD is called
+    // CLD is called thereafter to reset it. There is a bug (?) in MUSL where REP STOS is used
+    // without ensuring the flag is cleared
+
+    // 0000000000449f4d <__init_libc>:
+    //   449f4d:       53                      push   rbx
+    //   449f4e:       48 89 fa                mov    rdx,rdi
+    //   449f51:       31 c0                   xor    eax,eax
+    //   449f53:       b9 4c 00 00 00          mov    ecx,0x4c
+    //   449f58:       48 81 ec 50 01 00 00    sub    rsp,0x150
+    //   449f5f:       48 8d 7c 24 20          lea    rdi,[rsp+0x20]
+    //   449f64:       f3 ab                   rep stos DWORD PTR es:[rdi],eax
+
+    let df_register = sleigh
+        .register_from_name("DF")
+        .expect("failed to get DF register");
+    memory
+        .write(&df_register, 0u8.into())
+        .expect("failed to init DF register");
+}
+
+fn init_registers_aarch64(sleigh: &impl Sleigh, memory: &mut Memory) {
+    let sp = sleigh
+        .register_from_name("sp")
+        .expect("invalid stack register");
+    let registers = (0..30).map(|n| format!("x{n}"));
+
+    init_registers(sleigh, memory, &sp, registers);
+
+    // Init link register value to final return address
+    let link_register = sleigh
+        .register_from_name("x30")
+        .expect("invalid link register");
+    memory
+        .write(&link_register, EXIT_IP_ADDR.into())
+        .expect("failed to initialize link register");
+
+    // Initialize system register `dczid_el0`
+    //
+    // Per DDI0487L_b_a-profile_architecture_reference_manual.pdf
+    //
+    // Indicates the block size that is written with byte values of 0 by the DC ZVA (Data Cache
+    // Zero by Address) System instruction.
+    //
+    // - Bits [63:5] Reserved, RES0.
+    // - Bit [4] Data Zero Prohibited (DZP). This field indicates whether the use of `DC ZVA`
+    // instruction is permitted (0b0) or prohibited (0b1).
+    // - Bits [3:0] Block Size (BS). Log2 of the block size in words.
+    let dczid_el0 = sleigh
+        .register_from_name("dczid_el0")
+        .expect("unknown register");
+    memory
+        .write(&dczid_el0, 0x10u64.into())
+        .expect("failed to initialize dczid_el0");
+}
+
+fn init_registers(
+    sleigh: &impl Sleigh,
+    memory: &mut Memory,
+    stack_register: &VarnodeData,
+    registers: impl IntoIterator<Item = String>,
+) {
+    let mut bitvar = 0;
+    for register_name in registers.into_iter() {
         let mut bytes = Vec::with_capacity(8);
         for _ in 0..8 {
             let byte: SymbolicByte = [
@@ -173,31 +276,10 @@ fn init_registers(sleigh: &impl Sleigh, memory: &mut Memory) {
             .unwrap_or_else(|err| panic!("failed to write register {register_name}: {err}"));
     }
 
-    // Init RSP to stack address
-    let rsp = sleigh.register_from_name("RSP").expect("invalid register");
+    // Init stack register to stack address
     memory
-        .write(&rsp, INITIAL_STACK.into())
-        .expect("failed to initialize RSP");
-
-    // Initialize the DF register to 0. It appears to be a convention that whenever STD is called
-    // CLD is called thereafter to reset it. There is a bug (?) in MUSL where REP STOS is used
-    // without ensuring the flag is cleared
-
-    // 0000000000449f4d <__init_libc>:
-    //   449f4d:       53                      push   rbx
-    //   449f4e:       48 89 fa                mov    rdx,rdi
-    //   449f51:       31 c0                   xor    eax,eax
-    //   449f53:       b9 4c 00 00 00          mov    ecx,0x4c
-    //   449f58:       48 81 ec 50 01 00 00    sub    rsp,0x150
-    //   449f5f:       48 8d 7c 24 20          lea    rdi,[rsp+0x20]
-    //   449f64:       f3 ab                   rep stos DWORD PTR es:[rdi],eax
-
-    let df_register = sleigh
-        .register_from_name("DF")
-        .expect("failed to get DF register");
-    memory
-        .write(&df_register, 0u8.into())
-        .expect("failed to init DF register");
+        .write(stack_register, INITIAL_STACK.into())
+        .expect("failed to initialize stack register");
 }
 
 fn find_test_fixture(
@@ -439,7 +521,12 @@ fn doubler_32b() -> processor::Result<()> {
 }
 
 #[test]
-fn hello_world_linux() -> processor::Result<()> {
+fn hello_world_x86_linux() -> processor::Result<()> {
+    flexi_logger::Logger::try_with_env()
+        .unwrap()
+        .start()
+        .unwrap();
+
     // Build test fixture first
     let messages = escargot::CargoBuild::new()
         .bin("linux-syscalls")
@@ -460,8 +547,9 @@ fn hello_world_linux() -> processor::Result<()> {
     };
 
     let sleigh = Rc::new(x86_64_sleigh().expect("failed to build sleigh"));
-    let mut memory = memory_with_image(&sleigh, image);
-    init_registers(sleigh.as_ref(), &mut memory);
+    let rip = sleigh.register_from_name("RIP").expect("invalid register");
+    let mut memory = memory_with_image(&sleigh, image, &rip);
+    init_registers_x86_64(sleigh.as_ref(), &mut memory);
     initialize_libc_stack(&mut memory, sleigh.as_ref());
 
     let handler = ProcessorHandlerX86::new(sleigh.as_ref());
@@ -498,6 +586,88 @@ fn hello_world_linux() -> processor::Result<()> {
 }
 
 #[test]
+fn hello_world_aarch64_linux() -> processor::Result<()> {
+    flexi_logger::Logger::try_with_env()
+        .unwrap()
+        .start()
+        .unwrap();
+
+    // Build test fixture first
+    let messages = escargot::CargoBuild::new()
+        .bin("linux-syscalls")
+        .manifest_path("./test-fixtures/linux-syscalls/Cargo.toml")
+        .target("aarch64-unknown-linux-musl")
+        .env(
+            "RUSTFLAGS",
+            "-Ctarget-feature=+crt-static -Crelocation-model=static",
+        )
+        // On Ubuntu can install with sudo apt install gcc-aarch64-linux-gnu
+        .env(
+            "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER",
+            "aarch64-linux-gnu-gcc",
+        )
+        .exec()
+        .unwrap();
+
+    let image = match find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
+    let sleigh = Rc::new(common::aarch64_sleigh().expect("failed to build sleigh"));
+    let pc = sleigh.register_from_name("pc").expect("invalid register");
+    let mut memory = memory_with_image(&sleigh, image, &pc);
+    init_registers_aarch64(sleigh.as_ref(), &mut memory);
+    initialize_libc_stack(&mut memory, sleigh.as_ref());
+
+    let handler = arch::aarch64::processor::ProcessorHandler::new(sleigh.as_ref());
+    let emulator = arch::aarch64::emulator::Emulator::with_kernel(
+        sleigh.clone(),
+        LinuxKernel::with_config(arch::aarch64::linux::config()),
+    );
+    let mut processor = Processor::new(memory, emulator, handler);
+
+    loop {
+        let print_pcode = matches!(processor.state(), ProcessorState::Decode(_));
+        processor.step(sleigh.as_ref())?;
+
+        if print_pcode {
+            if let ProcessorState::Execute(e) = processor.state() {
+                for instr in &e.pcode().instructions {
+                    println!("{instr}");
+                }
+            }
+        }
+
+        // Debug
+        if matches!(processor.state(), ProcessorState::Decode(_)) {
+            let disassembly = processor.disassemble(sleigh.as_ref())?;
+            let encoded_instr = processor
+                .memory()
+                .read(&disassembly.origin)?
+                .into_le_bytes()
+                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            println!("Encoded instruction from memory: {encoded_instr}");
+            println!("Decoded: {instr}", instr = disassembly.instructions[0]);
+        }
+
+        if matches!(processor.state(), ProcessorState::Halt) {
+            assert_eq!(
+                processor.emulator().kernel().exit_status(),
+                Some(0),
+                "exit code should be 0"
+            );
+            return Ok(());
+        }
+    }
+}
+
+#[test]
 fn pcode_coverage() -> processor::Result<()> {
     // Build test fixture first
     let messages = escargot::CargoBuild::new()
@@ -515,10 +685,11 @@ fn pcode_coverage() -> processor::Result<()> {
     };
 
     let sleigh = x86_64_sleigh().expect("failed to build sleigh");
-    let mut memory = memory_with_image(&sleigh, image);
-    init_registers(&sleigh, &mut memory);
+    let rip = sleigh.register_from_name("RIP").expect("invalid register");
+    let mut memory = memory_with_image(&sleigh, image, &rip);
+    init_registers_x86_64(&sleigh, &mut memory);
 
-    // Init stack address in memory to magic EXIT_RIP value
+    // Init stack address in memory to magic EXIT_IP_ADDR value
     let stack_addr = VarnodeData {
         address: Address {
             offset: INITIAL_STACK,
@@ -526,19 +697,16 @@ fn pcode_coverage() -> processor::Result<()> {
                 .address_space_by_name("ram")
                 .expect("failed to find ram"),
         },
-        size: EXIT_RIP.to_le_bytes().len(),
+        size: EXIT_IP_ADDR.to_le_bytes().len(),
     };
     memory
-        .write(&stack_addr, EXIT_RIP.into())
+        .write(&stack_addr, EXIT_IP_ADDR.into())
         .expect("failed to initialize stack");
 
     let handler = ProcessorHandlerX86::new(&sleigh);
     let emulator = TracingEmulator::new(StandardPcodeEmulator::new(sleigh.address_spaces()));
     let mut processor = Processor::new(memory, emulator, handler);
 
-    let rip = sleigh
-        .register_from_name("RIP")
-        .expect("failed to get RIP register");
     loop {
         processor.step(&sleigh)?;
 
@@ -563,7 +731,8 @@ fn pcode_coverage() -> processor::Result<()> {
             .try_into()
             .expect("failed to concretize RIP");
 
-        if instruction_pointer == EXIT_RIP && matches!(processor.state(), ProcessorState::Fetch) {
+        if instruction_pointer == EXIT_IP_ADDR && matches!(processor.state(), ProcessorState::Fetch)
+        {
             break;
         }
     }
@@ -599,6 +768,110 @@ fn pcode_coverage() -> processor::Result<()> {
     // Int(GreaterThanOrEqual(Unsigned))
     // BranchIndirect -- though technically this is covered via Return
     assert_eq!(processor.emulator().executed_instructions().len(), 36);
+    Ok(())
+}
+
+#[test]
+fn pcode_coverage_aarch64() -> processor::Result<()> {
+    // Build test fixture first
+    let messages = escargot::CargoBuild::new()
+        .bin("pcode-coverage")
+        .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
+        .target("aarch64-unknown-none")
+        .exec()
+        .unwrap();
+
+    let image = match find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
+    let sleigh = common::aarch64_sleigh().expect("failed to build sleigh");
+    let pc = sleigh.register_from_name("pc").expect("invalid register");
+    let mut memory = memory_with_image(&sleigh, image, &pc);
+    init_registers_aarch64(&sleigh, &mut memory);
+
+    // Init stack address in memory to magic EXIT_IP_ADDR value
+    let stack_addr = VarnodeData {
+        address: Address {
+            offset: INITIAL_STACK,
+            address_space: sleigh
+                .address_space_by_name("ram")
+                .expect("failed to find ram"),
+        },
+        size: EXIT_IP_ADDR.to_le_bytes().len(),
+    };
+    memory
+        .write(&stack_addr, EXIT_IP_ADDR.into())
+        .expect("failed to initialize stack");
+
+    let handler = arch::aarch64::processor::ProcessorHandler::new(&sleigh);
+    let emulator = TracingEmulator::new(StandardPcodeEmulator::new(sleigh.address_spaces()));
+    let mut processor = Processor::new(memory, emulator, handler);
+
+    loop {
+        processor.step(&sleigh)?;
+
+        // Check if PC is the magic value
+        if matches!(processor.state(), ProcessorState::Decode(_)) {
+            let disassembly = processor.disassemble(&sleigh)?;
+            let encoded_instr = processor
+                .memory()
+                .read(&disassembly.origin)?
+                .into_le_bytes()
+                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            println!("Encoded instruction from memory: {encoded_instr}");
+            println!("Decoded: {disassembly}");
+        }
+
+        let instruction_pointer: u64 = processor
+            .memory()
+            .read(&pc)?
+            .try_into()
+            .expect("failed to concretize pc register");
+
+        if instruction_pointer == EXIT_IP_ADDR && matches!(processor.state(), ProcessorState::Fetch)
+        {
+            break;
+        }
+    }
+
+    let return_register = sleigh
+        .register_from_name("x0")
+        .expect("failed to get x0 register");
+    let return_value: u64 = processor
+        .memory()
+        .read(&return_register)?
+        .try_into()
+        .expect("failed to concretize return register");
+    assert_eq!(
+        return_value, 0,
+        "unexpected return value: {return_value:016x}"
+    );
+
+    processor
+        .emulator()
+        .executed_instructions()
+        .into_iter()
+        .for_each(|(opcode, count)| println!("Executed {opcode:?}: {count}"));
+
+    // Currently the following p-code instructions are not covered by this test:
+    //
+    // Piece
+    // Bool(Xor)
+    // Int(LessThanOrEqual(Signed))
+    // Int(LessThanOrEqual(Unsigned))
+    // Int(GreaterThan(Signed))
+    // Int(GreaterThan(Unsigned))
+    // Int(GreaterThanOrEqual(Signed))
+    // Int(GreaterThanOrEqual(Unsigned))
+    // BranchIndirect -- though technically this is covered via Return
+    assert_eq!(processor.emulator().executed_instructions().len(), 33);
     Ok(())
 }
 
@@ -647,7 +920,7 @@ fn z3_integration() -> processor::Result<()> {
     write_register(&mut memory, "RSP", &INITIAL_STACK.to_le_bytes());
     write_register(&mut memory, "RBP", &INITIAL_STACK.to_le_bytes());
 
-    // Put EXIT_RIP onto the stack. The final RET will trigger this.
+    // Put EXIT_IP_ADDR onto the stack. The final RET will trigger this.
     memory.write(
         &VarnodeData::new(
             Address::new(
@@ -656,9 +929,9 @@ fn z3_integration() -> processor::Result<()> {
                     .expect("failed to find ram"),
                 INITIAL_STACK,
             ),
-            EXIT_RIP.to_le_bytes().len(),
+            EXIT_IP_ADDR.to_le_bytes().len(),
         ),
-        EXIT_RIP.into(),
+        EXIT_IP_ADDR.into(),
     )?;
 
     let input_value = sym::SymbolicBitVec::with_size(32);
@@ -695,7 +968,7 @@ fn z3_integration() -> processor::Result<()> {
                 .expect("failed to read RIP")
                 .try_into()
                 .expect("failed to concretize RIP");
-            if rip_value == EXIT_RIP {
+            if rip_value == EXIT_IP_ADDR {
                 finished.push(processors.swap_remove(i));
 
                 // Do not update index since processor from end was moved here
@@ -860,7 +1133,7 @@ fn take_the_path_not_taken() -> processor::Result<()> {
     write_register(&mut memory, "RSP", &INITIAL_STACK.to_le_bytes());
     write_register(&mut memory, "RBP", &INITIAL_STACK.to_le_bytes());
 
-    // Put EXIT_RIP onto the stack. The final RET will trigger this.
+    // Put EXIT_IP_ADDR onto the stack. The final RET will trigger this.
     memory.write(
         &VarnodeData::new(
             Address::new(
@@ -869,9 +1142,9 @@ fn take_the_path_not_taken() -> processor::Result<()> {
                     .expect("failed to find ram"),
                 INITIAL_STACK,
             ),
-            EXIT_RIP.to_le_bytes().len(),
+            EXIT_IP_ADDR.to_le_bytes().len(),
         ),
-        EXIT_RIP.into(),
+        EXIT_IP_ADDR.into(),
     )?;
 
     // Create symbolic input
@@ -927,7 +1200,8 @@ fn take_the_path_not_taken() -> processor::Result<()> {
             .read(&rip)?
             .try_into()
             .expect("failed to concretize RIP");
-        if instruction_pointer == EXIT_RIP && matches!(processor.state(), ProcessorState::Fetch) {
+        if instruction_pointer == EXIT_IP_ADDR && matches!(processor.state(), ProcessorState::Fetch)
+        {
             break;
         }
     }


### PR DESCRIPTION
This adds support to the Linux kernel model to support additional architectures. Included AArch64 model with sufficient syscalls to execute hello world. Added this AArch64 example to the integration tests.

This assumes the build is being performed on an x86-64 platform which necessitates cross-compiling to AArch64. 

The Linux kernel model still defaults to x86-64 if additional configuration has not been provided. This will later be removed and be required to provide the architecture details.