### PR TITLE
Changes to Evaluator in sym crate

### DIFF
--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -737,8 +737,10 @@ fn take_the_path_not_taken() -> processor::Result<()> {
         if let Err(e) = processor.step(&sleigh) {
             if let processor::Error::SymbolicBranch { condition_origin } = &e {
                 let condition = processor.memory().read(condition_origin)?;
-                let evaluation =
-                    evaluator.evaluate(&processor.memory().read_bit(condition_origin)?);
+                let evaluation = evaluator
+                    .evaluate(&processor.memory().read_bit(condition_origin)?)
+                    .response
+                    .expect("evaluation should be concrete");
                 if evaluation {
                     branches.push(condition.not_equals(0u8.into()));
                 } else {


### PR DESCRIPTION
This makes a number of changes to the `Evaluator` in the `sym` crate. The API has been changed to return an `Evaluation` which includes additional details. The evaluator will no longer panic if the response is not a concrete value; in this case it will be `None` instead.

The evaluation also tracks which variables were used to perform the evaluation, as well as any unassigned variables encountered during the evaluation. The latter is only populated when the response is not concrete.

Finally the evaluator cache has been removed due to a known issue. This optimization is not necessary to include in the core evaluator.

Resolves #179 