### PR TITLE
Cleanup code to address clippy warnings and reorg integration tests

### DIFF
--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -252,7 +252,7 @@ impl AddressSpace {
     ///
     /// The address space id must have originated from the Ghidra library in the current process.
     pub unsafe fn from_ghidra_id(id: AddressSpaceId) -> AddressSpace {
-        AddressSpace::from(&*(id.0 as *const sys::AddrSpace))
+        AddressSpace::from(unsafe { &*(id.0 as *const sys::AddrSpace) })
     }
 }
 

--- a/crates/sym/src/buf.rs
+++ b/crates/sym/src/buf.rs
@@ -173,12 +173,12 @@ impl<const N: usize> SymbolicBitBuf<N> {
         F: FnOnce(&mut [MaybeUninit<SymbolicBit>]),
     {
         let mut bits: [std::mem::MaybeUninit<SymbolicBit>; N] =
-            std::mem::MaybeUninit::uninit().assume_init();
+            unsafe { std::mem::MaybeUninit::uninit().assume_init() };
 
         initializer(&mut bits);
 
         // SAFETY: Assumes all bits are initialized
-        let bits = (&bits as *const _ as *const [SymbolicBit; N]).read();
+        let bits = unsafe { (&bits as *const _ as *const [SymbolicBit; N]).read() };
 
         Self { bits }
     }
@@ -197,7 +197,7 @@ impl<const N: usize> SymbolicBitBuf<N> {
     pub fn equals(self, rhs: Self) -> SymbolicBit {
         self.bits
             .into_iter()
-            .zip(rhs.bits.into_iter())
+            .zip(rhs.bits)
             .map(|(lhs, rhs)| lhs.equals(rhs))
             .fold(SymbolicBit::Literal(true), |lhs, rhs| lhs & rhs)
     }
@@ -268,7 +268,6 @@ impl<const N: usize> SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::Not for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn not(mut self) -> Self::Output {
         for i in 0..N {
             let bit = std::mem::take(&mut self.bits[i]);
@@ -309,7 +308,6 @@ impl<const N: usize> std::ops::BitXorAssign for SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::BitAnd for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn bitand(mut self, rhs: Self) -> Self::Output {
         self &= rhs;
         self
@@ -319,7 +317,6 @@ impl<const N: usize> std::ops::BitAnd for SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::BitOr for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn bitor(mut self, rhs: Self) -> Self::Output {
         self |= rhs;
         self
@@ -329,7 +326,6 @@ impl<const N: usize> std::ops::BitOr for SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::BitXor for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn bitxor(mut self, rhs: Self) -> Self::Output {
         self ^= rhs;
         self
@@ -349,7 +345,6 @@ impl<const N: usize> std::ops::ShlAssign for SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::Shl for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn shl(mut self, rhs: Self) -> Self::Output {
         self <<= rhs;
         self
@@ -365,7 +360,6 @@ impl<const N: usize> std::ops::ShlAssign<usize> for SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::Shl<usize> for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn shl(mut self, rhs: usize) -> Self::Output {
         self <<= rhs;
         self
@@ -386,7 +380,6 @@ impl<const N: usize> std::ops::ShrAssign for SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::Shr for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn shr(mut self, rhs: Self) -> Self::Output {
         self >>= rhs;
         self
@@ -402,7 +395,6 @@ impl<const N: usize> std::ops::ShrAssign<usize> for SymbolicBitBuf<N> {
 impl<const N: usize> std::ops::Shr<usize> for SymbolicBitBuf<N> {
     type Output = Self;
 
-    #[must_use]
     fn shr(mut self, rhs: usize) -> Self::Output {
         self >>= rhs;
         self

--- a/crates/sym/src/eval.rs
+++ b/crates/sym/src/eval.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::rc::Rc;
 
 use crate::{SymbolicBit, SymbolicBitVec};
 

--- a/crates/sym/src/sym.rs
+++ b/crates/sym/src/sym.rs
@@ -250,8 +250,7 @@ impl SymbolicBitVec {
 
     pub fn signed_minimum_value(num_bits: usize) -> Self {
         Self {
-            bits: std::iter::repeat(SymbolicBit::Literal(false))
-                .take(num_bits - 1)
+            bits: std::iter::repeat_n(SymbolicBit::Literal(false), num_bits - 1)
                 .chain(std::iter::once(SymbolicBit::Literal(true)))
                 .collect(),
         }
@@ -259,8 +258,7 @@ impl SymbolicBitVec {
 
     pub fn signed_maximum_value(num_bits: usize) -> Self {
         Self {
-            bits: std::iter::repeat(SymbolicBit::Literal(true))
-                .take(num_bits - 1)
+            bits: std::iter::repeat_n(SymbolicBit::Literal(true), num_bits - 1)
                 .chain(std::iter::once(SymbolicBit::Literal(false)))
                 .collect(),
         }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -30,13 +30,5 @@ z3 = "0.12"
 # z3 = { version = "0.12", features = ["static-link-z3"] }
 
 [[test]]
-name = "x86_64_emulator"
-path = "x86_64_emulator.rs"
-
-[[test]]
-name = "sleigh"
-path = "sleigh.rs"
-
-[[test]]
-name = "hello_world"
-path = "hello_world.rs"
+name = "integration-tests"
+path = "main.rs"

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -1,4 +1,4 @@
-mod common;
+mod util;
 
 use std::rc::Rc;
 
@@ -8,6 +8,9 @@ use symbolic_pcode::arch;
 use symbolic_pcode::kernel::linux::LinuxKernel;
 use symbolic_pcode::mem::VarnodeDataStore;
 use symbolic_pcode::processor::{self, Processor, ProcessorState};
+
+use crate::common;
+use util::initialize_libc_stack;
 
 #[test]
 fn hello_world_x86_linux() -> processor::Result<()> {
@@ -36,7 +39,7 @@ fn hello_world_x86_linux() -> processor::Result<()> {
     let rip = sleigh.register_from_name("RIP").expect("invalid register");
     let mut memory = common::memory_with_image(&sleigh, image, &rip);
     common::init_registers_x86_64(sleigh.as_ref(), &mut memory);
-    common::initialize_libc_stack(&mut memory, sleigh.as_ref());
+    initialize_libc_stack(&mut memory, sleigh.as_ref());
 
     let handler = arch::x86::processor::ProcessorHandlerX86::new(sleigh.as_ref());
     let emulator =
@@ -104,7 +107,7 @@ fn hello_world_aarch64_linux() -> processor::Result<()> {
     let pc = sleigh.register_from_name("pc").expect("invalid register");
     let mut memory = common::memory_with_image(&sleigh, image, &pc);
     common::init_registers_aarch64(sleigh.as_ref(), &mut memory);
-    common::initialize_libc_stack(&mut memory, sleigh.as_ref());
+    initialize_libc_stack(&mut memory, sleigh.as_ref());
 
     let handler = arch::aarch64::processor::ProcessorHandler::new(sleigh.as_ref());
     let emulator = arch::aarch64::emulator::Emulator::with_kernel(

--- a/tests/hello_world/util.rs
+++ b/tests/hello_world/util.rs
@@ -1,0 +1,88 @@
+use libsla::{Address, Sleigh, VarnodeData};
+use sym::SymbolicBitVec;
+use symbolic_pcode::mem::VarnodeDataStore;
+
+use crate::common::{INITIAL_STACK, Memory};
+
+pub fn initialize_libc_stack(memory: &mut Memory, sleigh: &impl Sleigh) {
+    // The stack for libc programs:
+    // * argc
+    // * argv - list must be terminated by NULL pointer
+    // * envp - list must be terminated by NULL pointer
+    // * auxv - list must be terminated by NULL pointer
+    let ram = sleigh
+        .address_space_by_name("ram")
+        .expect("failed to find ram");
+    let argc = VarnodeData {
+        address: Address {
+            offset: INITIAL_STACK,
+            address_space: ram.clone(),
+        },
+        size: 8,
+    };
+    memory
+        .write(&argc, SymbolicBitVec::constant(1, u64::BITS as usize))
+        .expect("failed to initialize argc on stack");
+
+    // The argv list must be terminated by null pointer. Setting program name to null AND
+    // terminating the list with NULL, whence 16 bytes
+    //
+    // musl has support for null program name:
+    // https://git.musl-libc.org/cgit/musl/tree/src/env/__libc_start_main.c
+    let argv = VarnodeData {
+        address: Address {
+            offset: argc.address.offset + argc.size as u64,
+            address_space: ram.clone(),
+        },
+        size: 16,
+    };
+    memory
+        .write(&argv, SymbolicBitVec::constant(0, (2 * u64::BITS) as usize))
+        .expect("failed to initialize argv");
+
+    let envp = VarnodeData {
+        address: Address {
+            offset: argv.address.offset + argv.size as u64,
+            address_space: ram.clone(),
+        },
+        size: 8,
+    };
+    memory
+        .write(&envp, SymbolicBitVec::constant(0, u64::BITS as usize))
+        .expect("failed to initialize envp");
+
+    // musl targets initialize the libc pagesize using aux[AT_PAGESZ]. For architectures without a
+    // hardcoded value the libc pagesize is used. For example x86-64 has a hardcoded value of 4096
+    // and so this is ignored. However for aarch64 there is no hardcoded value. This must be
+    // supplied otherwise a pagesize of 0 will be used in some cases.
+    let mut auxv = VarnodeData {
+        address: Address {
+            offset: envp.address.offset + envp.size as u64,
+            address_space: ram.clone(),
+        },
+        size: 8,
+    };
+
+    // The index for AT_PAGESZ
+    let at_pagesz = 6;
+    memory
+        .write(
+            &auxv,
+            SymbolicBitVec::constant(at_pagesz, u64::BITS as usize),
+        )
+        .expect("failed to write AT_PAGESZ into auxv");
+    auxv.address.offset += auxv.size as u64;
+
+    let page_size = 4096;
+    memory
+        .write(
+            &auxv,
+            SymbolicBitVec::constant(page_size, u64::BITS as usize),
+        )
+        .expect("failed to write page size into auxv");
+    auxv.address.offset += auxv.size as u64;
+
+    memory
+        .write(&auxv, SymbolicBitVec::constant(0, u64::BITS as usize))
+        .expect("failed to initialize auxv");
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,0 +1,4 @@
+mod common;
+mod hello_world;
+mod sleigh;
+mod x86_64_emulator;

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -1,6 +1,3 @@
-mod common;
-
-use common::{Memory, TracingEmulator, x86_64_sleigh};
 use libsla::{Address, Sleigh, VarnodeData};
 use pcode_ops::PcodeOps;
 use sym::{self, Evaluator, SymbolicBitVec, VariableAssignments};
@@ -10,6 +7,8 @@ use symbolic_pcode::{
     mem::{MemoryTree, VarnodeDataStore},
     processor::{self, BranchingProcessor, Processor, ProcessorState},
 };
+
+use crate::common::{self, Memory, TracingEmulator, x86_64_sleigh};
 
 /// Confirms the functionality of general-purpose x86-64 registers and overlapping behavior.
 #[test]
@@ -712,7 +711,7 @@ fn take_the_path_not_taken() -> processor::Result<()> {
     // symbolic value, we will evaluate the branch using the concrete value instead.
     let concrete_input = -3i32;
     let concrete_input = SymbolicBitVec::from(concrete_input as u32);
-    let mut evaluator = Evaluator::new(VariableAssignments::from_bitvecs(
+    let evaluator = Evaluator::new(VariableAssignments::from_bitvecs(
         &input_value,
         &concrete_input,
     ));


### PR DESCRIPTION
Addressed Rust clippy warnings in source code. Also needed to reorganize the integration tests into a single test executable in order to prevent dead code warnings from being emitted for non-dead code. See https://github.com/rust-lang/rust/issues/46379 for details.