### PR TITLE
Force RUSTFLAGS to be empty for pcode coverage test harness

### DIFF
--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -227,6 +227,7 @@ fn pcode_coverage() -> processor::Result<()> {
     let messages = escargot::CargoBuild::new()
         .bin("pcode-coverage")
         .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
+        .env("RUSTFLAGS", "")
         .target("x86_64-unknown-none")
         .exec()
         .unwrap();
@@ -332,6 +333,7 @@ fn pcode_coverage_aarch64() -> processor::Result<()> {
     let messages = escargot::CargoBuild::new()
         .bin("pcode-coverage")
         .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
+        .env("RUSTFLAGS", "")
         .target("aarch64-unknown-none")
         .exec()
         .unwrap();


### PR DESCRIPTION
When running code coverage tests, these binaries will fail to build with `RUSTFLAGS="-C instrument-coverage"`. This currently does not fail in Github actions by happenstance, as the test harnesses are built prior when running the tests without coverage.