### PR TITLE
Simplify reading and writing memory values

### DIFF
--- a/crates/pcode-ops/src/convert.rs
+++ b/crates/pcode-ops/src/convert.rs
@@ -75,6 +75,12 @@ impl<const N: usize, T: PcodeOps> TryFrom<PcodeValue<T>> for [u8; N] {
     }
 }
 
+impl<const N: usize, T: PcodeOps> From<[u8; N]> for PcodeValue<T> {
+    fn from(value: [u8; N]) -> Self {
+        value.into_iter().collect()
+    }
+}
+
 impl<T: PcodeOps> From<T> for PcodeValue<T> {
     fn from(value: T) -> Self {
         Self { inner: value }
@@ -89,6 +95,12 @@ impl<T: PcodeOps> Deref for PcodeValue<T> {
     }
 }
 
+impl<T: PcodeOps> FromIterator<u8> for PcodeValue<T> {
+    fn from_iter<I: IntoIterator<Item = u8>>(iter: I) -> Self {
+        PcodeValue::from(iter.into_iter().map(T::Byte::from).collect::<T>())
+    }
+}
+
 macro_rules! impl_tryfrom_pcodevalue {
     ($target:ty) => {
         impl_tryfrom_pcodevalue!($target, { std::mem::size_of::<$target>() }, {
@@ -96,6 +108,12 @@ macro_rules! impl_tryfrom_pcodevalue {
         });
     };
     ($target:ty, $size:expr, $signed:expr) => {
+        impl<T: PcodeOps> From<$target> for PcodeValue<T> {
+            fn from(value: $target) -> PcodeValue<T> {
+                PcodeValue::from(T::from_le(value))
+            }
+        }
+
         impl<T: PcodeOps> TryFrom<PcodeValue<T>> for $target {
             type Error = TryFromPcodeValueError;
 

--- a/crates/pcode/src/arch/x86/processor.rs
+++ b/crates/pcode/src/arch/x86/processor.rs
@@ -2,7 +2,7 @@ use libsla::{Address, AddressSpace, Sleigh, VarnodeData};
 
 use crate::mem::VarnodeDataStore;
 use crate::processor::{Error, PcodeExecution, ProcessorResponseHandler, Result};
-use pcode_ops::{PcodeOps, convert::PcodeValue};
+use pcode_ops::convert::PcodeValue;
 
 #[derive(Debug, Clone)]
 pub struct ProcessorHandlerX86 {
@@ -59,13 +59,13 @@ impl ProcessorResponseHandler for ProcessorHandlerX86 {
             ))
         })?;
 
-        memory.write(&self.rip, M::Value::from_le(rip_value))?;
+        memory.write_value(&self.rip, rip_value)?;
 
         Ok(())
     }
 
     fn jumped<M: VarnodeDataStore>(&mut self, memory: &mut M, address: &Address) -> Result<()> {
-        memory.write(&self.rip, M::Value::from_le(address.offset))?;
+        memory.write_value(&self.rip, address.offset)?;
         Ok(())
     }
 }

--- a/crates/pcode/src/kernel/linux.rs
+++ b/crates/pcode/src/kernel/linux.rs
@@ -254,7 +254,7 @@ impl LinuxKernel {
                 Address::new(ram.clone(), pfds + (8 * pfds_offset) as u64),
                 std::mem::size_of::<PollFd>(),
             );
-            let bytes = PcodeValue::from(memory.read(&fds)?).try_into()?;
+            let bytes = memory.read_value(&fds)?.try_into()?;
 
             // SAFETY: All byte combinations are valid
             poll_fds.push(unsafe {
@@ -558,7 +558,7 @@ impl LinuxKernel {
             .address_space_by_name("ram")
             .expect("failed to find ram");
         let target = VarnodeData::new(Address::new(ram, buf), count as usize);
-        let bytes: Vec<u8> = PcodeValue::from(memory.read(&target)?).try_into()?;
+        let bytes: Vec<u8> = memory.read_value(&target)?.try_into()?;
 
         match fd {
             1 => {
@@ -598,7 +598,7 @@ impl LinuxKernel {
 
     fn syscall_num<M: VarnodeDataStore>(&self, sleigh: &impl Sleigh, memory: &M) -> Result<u32> {
         let syscall_reg = sleigh.register_from_name(&self.arch_config.syscall_num_register)?;
-        let pcode_value = PcodeValue::from(memory.read(&syscall_reg)?);
+        let pcode_value = memory.read_value(&syscall_reg)?;
         Ok(u32::try_from(pcode_value)?)
     }
 
@@ -627,6 +627,6 @@ impl LinuxKernel {
             register.size = std::mem::size_of::<T>();
         }
 
-        Ok(T::try_from(PcodeValue::from(memory.read(&register)?))?)
+        Ok(T::try_from(memory.read_value(&register)?)?)
     }
 }

--- a/crates/pcode/src/mem.rs
+++ b/crates/pcode/src/mem.rs
@@ -49,10 +49,12 @@ pub trait VarnodeDataStore {
         data: <Self::Value as PcodeOps>::Bit,
     ) -> Result<()>;
 
+    /// Read a [PcodeValue] from memory.
     fn read_value(&self, source: &VarnodeData) -> Result<PcodeValue<Self::Value>> {
         Ok(PcodeValue::from(self.read(source)?))
     }
 
+    /// Write a value which can be converted into a [PcodeValue].
     fn write_value(
         &mut self,
         destination: &VarnodeData,

--- a/crates/pcode/src/mem.rs
+++ b/crates/pcode/src/mem.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, rc::Rc};
 use thiserror;
 
 use libsla::{Address, AddressSpaceId, AddressSpaceType, LoadImage, VarnodeData};
-use pcode_ops::{BitwisePcodeOps, PcodeOps};
+use pcode_ops::{BitwisePcodeOps, PcodeOps, convert::PcodeValue};
 
 /// Memory result type
 pub type Result<T> = std::result::Result<T, Error>;
@@ -48,6 +48,18 @@ pub trait VarnodeDataStore {
         destination: &VarnodeData,
         data: <Self::Value as PcodeOps>::Bit,
     ) -> Result<()>;
+
+    fn read_value(&self, source: &VarnodeData) -> Result<PcodeValue<Self::Value>> {
+        Ok(PcodeValue::from(self.read(source)?))
+    }
+
+    fn write_value(
+        &mut self,
+        destination: &VarnodeData,
+        data: impl Into<PcodeValue<Self::Value>>,
+    ) -> Result<()> {
+        self.write(destination, data.into().into_inner())
+    }
 }
 
 /// Generic memory structure that stores [PcodeOps::Byte] keyed on [AddressSpaceId]. This structure


### PR DESCRIPTION
Added `read_value` and `write_value` for `VarnodeDataStore` for reading and writing `PcodeValue`. Also added several conversion routines for `PcodeValue` that enabled direct use of `write_value` in many places, enabling replacement of several complex conversions.

Resolves #171 