### PR TITLE
Move pcode coverage tests to separate file

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,10 +1,9 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
-use std::{collections::BTreeMap, fs};
 
-use libsla::{Address, GhidraSleigh, OpCode, PcodeInstruction, Sleigh, VarnodeData};
+use libsla::{Address, GhidraSleigh, Sleigh, VarnodeData};
 use sym::{SymbolicBit, SymbolicBitVec, SymbolicByte};
-use symbolic_pcode::emulator::{self, ControlFlow, PcodeEmulator, StandardPcodeEmulator};
 use symbolic_pcode::mem::{GenericMemory, VarnodeDataStore};
 
 static X86_64_SLA: OnceLock<PathBuf> = OnceLock::new();
@@ -24,113 +23,6 @@ pub const INITIAL_STACK: u64 = 0x8000000000;
 pub const EXIT_IP_ADDR: u64 = 0xFEEDBEEF0BADF00D;
 
 pub type Memory = GenericMemory<SymbolicBitVec>;
-
-#[derive(Debug, Clone)]
-pub struct TracingEmulator {
-    inner: StandardPcodeEmulator,
-    executed_instructions: std::cell::RefCell<BTreeMap<OpCode, usize>>,
-}
-
-impl PcodeEmulator for TracingEmulator {
-    fn emulate<T: VarnodeDataStore>(
-        &mut self,
-        memory: &mut T,
-        instruction: &PcodeInstruction,
-    ) -> emulator::Result<ControlFlow> {
-        //println!("Executing: {instruction}");
-        match &instruction.op_code {
-            OpCode::Store => (),
-            OpCode::Branch
-            | OpCode::BranchIndirect
-            | OpCode::BranchConditional
-            | OpCode::Call
-            | OpCode::CallIndirect
-            | OpCode::Return => (),
-            _ => {
-                /*
-                for instr_input in instruction.inputs.iter() {
-                    let input_result = memory.read(instr_input);
-                    let input_result = match input_result {
-                        Ok(x) => PcodeValue::from(x),
-                        Err(err) => {
-                            println!("Failed to read input {instr_input}: {err}");
-                            break;
-                        }
-                    };
-
-                    match u128::try_from(input_result) {
-                        Ok(value) => {
-                            println!(
-                                "Input {instr_input} = {value:0width$x}",
-                                width = 2 * instr_input.size
-                            );
-                        }
-                        Err(TryFromPcodeValueError::InvalidSize) => {
-                            println!("Input {instr_input} = Large value")
-                        }
-                        Err(TryFromPcodeValueError::InvalidByte { index }) => {
-                            println!("Input {instr_input} = Symbolic value @ {index}")
-                        }
-                    }
-                }
-                    */
-            }
-        };
-
-        let result = self.inner.emulate(memory, instruction)?;
-
-        /*
-        match &instruction.op_code {
-            OpCode::Store => println!("Store"),
-            OpCode::Branch
-            | OpCode::BranchIndirect
-            | OpCode::BranchConditional
-            | OpCode::Call
-            | OpCode::CallIndirect
-            | OpCode::Return => {
-                println!("Branch: {result:?}")
-            }
-            _ => {
-                let output_result = memory.read(instruction.output.as_ref().unwrap()).unwrap();
-                let output =
-                    <<T as VarnodeDataStore>::Value as TryInto<u64>>::try_into(output_result);
-                if let Ok(output) = output {
-                    println!(
-                        "Output: {output:0width$x}",
-                        width = 2 * instruction.output.as_ref().unwrap().size
-                    );
-                } else {
-                    println!("Output: Symbolic");
-                }
-            }
-        };
-        */
-
-        *self
-            .executed_instructions
-            .borrow_mut()
-            .entry(instruction.op_code)
-            .or_default() += 1;
-        Ok(result)
-    }
-}
-
-impl TracingEmulator {
-    pub fn new(inner: StandardPcodeEmulator) -> Self {
-        Self {
-            inner,
-            executed_instructions: Default::default(),
-        }
-    }
-
-    pub fn executed_instructions(&self) -> BTreeMap<OpCode, usize> {
-        self.executed_instructions
-            .borrow()
-            .iter()
-            .map(|(&op, &count)| (op, count))
-            .collect()
-    }
-}
 
 fn compile_x86_64_slaspec() -> sleigh_compiler::Result<PathBuf> {
     let sla_path = std::path::Path::new(env!("CARGO_TARGET_TMPDIR")).join("x86-64.sla");

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,4 +1,5 @@
 mod common;
 mod hello_world;
+mod pcode_coverage;
 mod sleigh;
 mod x86_64_emulator;

--- a/tests/pcode_coverage.rs
+++ b/tests/pcode_coverage.rs
@@ -1,0 +1,225 @@
+mod util;
+
+use libsla::{Address, Sleigh, VarnodeData};
+use pcode_ops::PcodeOps;
+use symbolic_pcode::{
+    arch::{self, x86::processor::ProcessorHandlerX86},
+    emulator::StandardPcodeEmulator,
+    mem::VarnodeDataStore,
+    processor::{self, Processor, ProcessorState},
+};
+
+use crate::common::{self, x86_64_sleigh};
+use util::TracingEmulator;
+
+#[test]
+fn pcode_coverage() -> processor::Result<()> {
+    // Build test fixture first
+    let messages = escargot::CargoBuild::new()
+        .bin("pcode-coverage")
+        .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
+        .env("RUSTFLAGS", "")
+        .target("x86_64-unknown-none")
+        .exec()
+        .unwrap();
+
+    let image = match common::find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
+    let sleigh = x86_64_sleigh().expect("failed to build sleigh");
+    let rip = sleigh.register_from_name("RIP").expect("invalid register");
+    let mut memory = common::memory_with_image(&sleigh, image, &rip);
+    common::init_registers_x86_64(&sleigh, &mut memory);
+
+    // Init stack address in memory to magic EXIT_IP_ADDR value
+    let stack_addr = VarnodeData {
+        address: Address {
+            offset: common::INITIAL_STACK,
+            address_space: sleigh
+                .address_space_by_name("ram")
+                .expect("failed to find ram"),
+        },
+        size: common::EXIT_IP_ADDR.to_le_bytes().len(),
+    };
+    memory
+        .write(&stack_addr, common::EXIT_IP_ADDR.into())
+        .expect("failed to initialize stack");
+
+    let handler = ProcessorHandlerX86::new(&sleigh);
+    let emulator = TracingEmulator::new(StandardPcodeEmulator::new(sleigh.address_spaces()));
+    let mut processor = Processor::new(memory, emulator, handler);
+
+    loop {
+        processor.step(&sleigh)?;
+
+        // Check if RIP is the magic value
+        if matches!(processor.state(), ProcessorState::Decode(_)) {
+            let disassembly = processor.disassemble(&sleigh)?;
+            let encoded_instr = processor
+                .memory()
+                .read(&disassembly.origin)?
+                .into_le_bytes()
+                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            println!("Encoded instruction from memory: {encoded_instr}");
+            println!("Decoded: {disassembly}");
+        }
+
+        let instruction_pointer: u64 = processor
+            .memory()
+            .read(&rip)?
+            .try_into()
+            .expect("failed to concretize RIP");
+
+        if instruction_pointer == common::EXIT_IP_ADDR
+            && matches!(processor.state(), ProcessorState::Fetch)
+        {
+            break;
+        }
+    }
+
+    let rax = sleigh
+        .register_from_name("RAX")
+        .expect("failed to get RAX register");
+    let return_value: u64 = processor
+        .memory()
+        .read(&rax)?
+        .try_into()
+        .expect("failed to concretize RAX");
+    assert_eq!(
+        return_value, 0,
+        "unexpected return value: {return_value:016x}"
+    );
+
+    processor
+        .emulator()
+        .executed_instructions()
+        .into_iter()
+        .for_each(|(opcode, count)| println!("Executed {opcode:?}: {count}"));
+
+    // Currently the following p-code instructions are not covered by this test:
+    //
+    // Piece
+    // Bool(Xor)
+    // Int(LessThanOrEqual(Signed))
+    // Int(LessThanOrEqual(Unsigned))
+    // Int(GreaterThan(Signed))
+    // Int(GreaterThan(Unsigned))
+    // Int(GreaterThanOrEqual(Signed))
+    // Int(GreaterThanOrEqual(Unsigned))
+    // BranchIndirect -- though technically this is covered via Return
+    assert_eq!(processor.emulator().executed_instructions().len(), 36);
+    Ok(())
+}
+
+#[test]
+fn pcode_coverage_aarch64() -> processor::Result<()> {
+    // Build test fixture first
+    let messages = escargot::CargoBuild::new()
+        .bin("pcode-coverage")
+        .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
+        .env("RUSTFLAGS", "")
+        .target("aarch64-unknown-none")
+        .exec()
+        .unwrap();
+
+    let image = match common::find_test_fixture(messages) {
+        Ok(image) => image,
+        Err(messages) => {
+            panic!("Failed to find test fixture: {messages:?}");
+        }
+    };
+
+    let sleigh = common::aarch64_sleigh().expect("failed to build sleigh");
+    let pc = sleigh.register_from_name("pc").expect("invalid register");
+    let mut memory = common::memory_with_image(&sleigh, image, &pc);
+    common::init_registers_aarch64(&sleigh, &mut memory);
+
+    // Init stack address in memory to magic EXIT_IP_ADDR value
+    let stack_addr = VarnodeData {
+        address: Address {
+            offset: common::INITIAL_STACK,
+            address_space: sleigh
+                .address_space_by_name("ram")
+                .expect("failed to find ram"),
+        },
+        size: common::EXIT_IP_ADDR.to_le_bytes().len(),
+    };
+    memory
+        .write(&stack_addr, common::EXIT_IP_ADDR.into())
+        .expect("failed to initialize stack");
+
+    let handler = arch::aarch64::processor::ProcessorHandler::new(&sleigh);
+    let emulator = TracingEmulator::new(StandardPcodeEmulator::new(sleigh.address_spaces()));
+    let mut processor = Processor::new(memory, emulator, handler);
+
+    loop {
+        processor.step(&sleigh)?;
+
+        // Check if PC is the magic value
+        if matches!(processor.state(), ProcessorState::Decode(_)) {
+            let disassembly = processor.disassemble(&sleigh)?;
+            let encoded_instr = processor
+                .memory()
+                .read(&disassembly.origin)?
+                .into_le_bytes()
+                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            println!("Encoded instruction from memory: {encoded_instr}");
+            println!("Decoded: {disassembly}");
+        }
+
+        let instruction_pointer: u64 = processor
+            .memory()
+            .read(&pc)?
+            .try_into()
+            .expect("failed to concretize pc register");
+
+        if instruction_pointer == common::EXIT_IP_ADDR
+            && matches!(processor.state(), ProcessorState::Fetch)
+        {
+            break;
+        }
+    }
+
+    let return_register = sleigh
+        .register_from_name("x0")
+        .expect("failed to get x0 register");
+    let return_value: u64 = processor
+        .memory()
+        .read(&return_register)?
+        .try_into()
+        .expect("failed to concretize return register");
+    assert_eq!(
+        return_value, 0,
+        "unexpected return value: {return_value:016x}"
+    );
+
+    processor
+        .emulator()
+        .executed_instructions()
+        .into_iter()
+        .for_each(|(opcode, count)| println!("Executed {opcode:?}: {count}"));
+
+    // Currently the following p-code instructions are not covered by this test:
+    //
+    // Piece
+    // Bool(Xor)
+    // Int(LessThanOrEqual(Signed))
+    // Int(LessThanOrEqual(Unsigned))
+    // Int(GreaterThan(Signed))
+    // Int(GreaterThan(Unsigned))
+    // Int(GreaterThanOrEqual(Signed))
+    // Int(GreaterThanOrEqual(Unsigned))
+    // BranchIndirect -- though technically this is covered via Return
+    assert_eq!(processor.emulator().executed_instructions().len(), 33);
+    Ok(())
+}

--- a/tests/pcode_coverage/util.rs
+++ b/tests/pcode_coverage/util.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeMap;
+
+use libsla::{OpCode, PcodeInstruction};
+use symbolic_pcode::{
+    emulator::{self, ControlFlow, PcodeEmulator, StandardPcodeEmulator},
+    mem::VarnodeDataStore,
+};
+
+#[derive(Debug, Clone)]
+pub struct TracingEmulator {
+    inner: StandardPcodeEmulator,
+    executed_instructions: std::cell::RefCell<BTreeMap<OpCode, usize>>,
+}
+
+impl PcodeEmulator for TracingEmulator {
+    fn emulate<T: VarnodeDataStore>(
+        &mut self,
+        memory: &mut T,
+        instruction: &PcodeInstruction,
+    ) -> emulator::Result<ControlFlow> {
+        //println!("Executing: {instruction}");
+        match &instruction.op_code {
+            OpCode::Store => (),
+            OpCode::Branch
+            | OpCode::BranchIndirect
+            | OpCode::BranchConditional
+            | OpCode::Call
+            | OpCode::CallIndirect
+            | OpCode::Return => (),
+            _ => {
+                /*
+                for instr_input in instruction.inputs.iter() {
+                    let input_result = memory.read(instr_input);
+                    let input_result = match input_result {
+                        Ok(x) => PcodeValue::from(x),
+                        Err(err) => {
+                            println!("Failed to read input {instr_input}: {err}");
+                            break;
+                        }
+                    };
+
+                    match u128::try_from(input_result) {
+                        Ok(value) => {
+                            println!(
+                                "Input {instr_input} = {value:0width$x}",
+                                width = 2 * instr_input.size
+                            );
+                        }
+                        Err(TryFromPcodeValueError::InvalidSize) => {
+                            println!("Input {instr_input} = Large value")
+                        }
+                        Err(TryFromPcodeValueError::InvalidByte { index }) => {
+                            println!("Input {instr_input} = Symbolic value @ {index}")
+                        }
+                    }
+                }
+                    */
+            }
+        };
+
+        let result = self.inner.emulate(memory, instruction)?;
+
+        /*
+        match &instruction.op_code {
+            OpCode::Store => println!("Store"),
+            OpCode::Branch
+            | OpCode::BranchIndirect
+            | OpCode::BranchConditional
+            | OpCode::Call
+            | OpCode::CallIndirect
+            | OpCode::Return => {
+                println!("Branch: {result:?}")
+            }
+            _ => {
+                let output_result = memory.read(instruction.output.as_ref().unwrap()).unwrap();
+                let output =
+                    <<T as VarnodeDataStore>::Value as TryInto<u64>>::try_into(output_result);
+                if let Ok(output) = output {
+                    println!(
+                        "Output: {output:0width$x}",
+                        width = 2 * instruction.output.as_ref().unwrap().size
+                    );
+                } else {
+                    println!("Output: Symbolic");
+                }
+            }
+        };
+        */
+
+        *self
+            .executed_instructions
+            .borrow_mut()
+            .entry(instruction.op_code)
+            .or_default() += 1;
+        Ok(result)
+    }
+}
+
+impl TracingEmulator {
+    pub fn new(inner: StandardPcodeEmulator) -> Self {
+        Self {
+            inner,
+            executed_instructions: Default::default(),
+        }
+    }
+
+    pub fn executed_instructions(&self) -> BTreeMap<OpCode, usize> {
+        self.executed_instructions
+            .borrow()
+            .iter()
+            .map(|(&op, &count)| (op, count))
+            .collect()
+    }
+}

--- a/tests/x86_64_emulator.rs
+++ b/tests/x86_64_emulator.rs
@@ -2,13 +2,13 @@ use libsla::{Address, Sleigh, VarnodeData};
 use pcode_ops::PcodeOps;
 use sym::{self, Evaluator, SymbolicBitVec, VariableAssignments};
 use symbolic_pcode::{
-    arch::{self, x86::processor::ProcessorHandlerX86},
+    arch::x86::processor::ProcessorHandlerX86,
     emulator::StandardPcodeEmulator,
     mem::{MemoryTree, VarnodeDataStore},
     processor::{self, BranchingProcessor, Processor, ProcessorState},
 };
 
-use crate::common::{self, Memory, TracingEmulator, x86_64_sleigh};
+use crate::common::{self, Memory, x86_64_sleigh};
 
 /// Confirms the functionality of general-purpose x86-64 registers and overlapping behavior.
 #[test]
@@ -18,19 +18,19 @@ fn x86_64_registers() {
     let write_register = |memory: &mut Memory, name: &str, data: &[u8]| {
         let register = sleigh
             .register_from_name(name)
-            .expect(&format!("invalid register {name}"));
+            .unwrap_or_else(|_| panic!("invalid register {name}"));
         memory
-            .write(&register, data.into_iter().copied().collect())
-            .expect(&format!("failed to write register {name}"));
+            .write(&register, data.iter().copied().collect())
+            .unwrap_or_else(|_| panic!("failed to write register {name}"));
     };
 
     let read_register = |memory: &Memory, name: &str| {
         let register = sleigh
             .register_from_name(name)
-            .expect(&format!("invalid register {name}"));
+            .unwrap_or_else(|_| panic!("invalid register {name}"));
         memory
             .read(&register)
-            .expect(&format!("failed to read register {name}"))
+            .unwrap_or_else(|_| panic!("failed to read register {name}"))
     };
 
     let mut memory = Memory::default();
@@ -87,8 +87,7 @@ fn x86_64_registers() {
             .expect("failed to convert to u32");
         assert_eq!(e, 0x44332211);
 
-        let name = format!("{register}");
-        let b: u16 = read_register(&memory, &name)
+        let b: u16 = read_register(&memory, register)
             .try_into()
             .expect("failed to convert to u16");
         assert_eq!(b, 0x2211);
@@ -222,218 +221,6 @@ fn doubler_32b() -> processor::Result<()> {
 }
 
 #[test]
-fn pcode_coverage() -> processor::Result<()> {
-    // Build test fixture first
-    let messages = escargot::CargoBuild::new()
-        .bin("pcode-coverage")
-        .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
-        .env("RUSTFLAGS", "")
-        .target("x86_64-unknown-none")
-        .exec()
-        .unwrap();
-
-    let image = match common::find_test_fixture(messages) {
-        Ok(image) => image,
-        Err(messages) => {
-            panic!("Failed to find test fixture: {messages:?}");
-        }
-    };
-
-    let sleigh = x86_64_sleigh().expect("failed to build sleigh");
-    let rip = sleigh.register_from_name("RIP").expect("invalid register");
-    let mut memory = common::memory_with_image(&sleigh, image, &rip);
-    common::init_registers_x86_64(&sleigh, &mut memory);
-
-    // Init stack address in memory to magic EXIT_IP_ADDR value
-    let stack_addr = VarnodeData {
-        address: Address {
-            offset: common::INITIAL_STACK,
-            address_space: sleigh
-                .address_space_by_name("ram")
-                .expect("failed to find ram"),
-        },
-        size: common::EXIT_IP_ADDR.to_le_bytes().len(),
-    };
-    memory
-        .write(&stack_addr, common::EXIT_IP_ADDR.into())
-        .expect("failed to initialize stack");
-
-    let handler = ProcessorHandlerX86::new(&sleigh);
-    let emulator = TracingEmulator::new(StandardPcodeEmulator::new(sleigh.address_spaces()));
-    let mut processor = Processor::new(memory, emulator, handler);
-
-    loop {
-        processor.step(&sleigh)?;
-
-        // Check if RIP is the magic value
-        if matches!(processor.state(), ProcessorState::Decode(_)) {
-            let disassembly = processor.disassemble(&sleigh)?;
-            let encoded_instr = processor
-                .memory()
-                .read(&disassembly.origin)?
-                .into_le_bytes()
-                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
-                .collect::<Vec<_>>()
-                .join(" ");
-
-            println!("Encoded instruction from memory: {encoded_instr}");
-            println!("Decoded: {disassembly}");
-        }
-
-        let instruction_pointer: u64 = processor
-            .memory()
-            .read(&rip)?
-            .try_into()
-            .expect("failed to concretize RIP");
-
-        if instruction_pointer == common::EXIT_IP_ADDR
-            && matches!(processor.state(), ProcessorState::Fetch)
-        {
-            break;
-        }
-    }
-
-    let rax = sleigh
-        .register_from_name("RAX")
-        .expect("failed to get RAX register");
-    let return_value: u64 = processor
-        .memory()
-        .read(&rax)?
-        .try_into()
-        .expect("failed to concretize RAX");
-    assert_eq!(
-        return_value, 0,
-        "unexpected return value: {return_value:016x}"
-    );
-
-    processor
-        .emulator()
-        .executed_instructions()
-        .into_iter()
-        .for_each(|(opcode, count)| println!("Executed {opcode:?}: {count}"));
-
-    // Currently the following p-code instructions are not covered by this test:
-    //
-    // Piece
-    // Bool(Xor)
-    // Int(LessThanOrEqual(Signed))
-    // Int(LessThanOrEqual(Unsigned))
-    // Int(GreaterThan(Signed))
-    // Int(GreaterThan(Unsigned))
-    // Int(GreaterThanOrEqual(Signed))
-    // Int(GreaterThanOrEqual(Unsigned))
-    // BranchIndirect -- though technically this is covered via Return
-    assert_eq!(processor.emulator().executed_instructions().len(), 36);
-    Ok(())
-}
-
-#[test]
-fn pcode_coverage_aarch64() -> processor::Result<()> {
-    // Build test fixture first
-    let messages = escargot::CargoBuild::new()
-        .bin("pcode-coverage")
-        .manifest_path("./test-fixtures/pcode-coverage/Cargo.toml")
-        .env("RUSTFLAGS", "")
-        .target("aarch64-unknown-none")
-        .exec()
-        .unwrap();
-
-    let image = match common::find_test_fixture(messages) {
-        Ok(image) => image,
-        Err(messages) => {
-            panic!("Failed to find test fixture: {messages:?}");
-        }
-    };
-
-    let sleigh = common::aarch64_sleigh().expect("failed to build sleigh");
-    let pc = sleigh.register_from_name("pc").expect("invalid register");
-    let mut memory = common::memory_with_image(&sleigh, image, &pc);
-    common::init_registers_aarch64(&sleigh, &mut memory);
-
-    // Init stack address in memory to magic EXIT_IP_ADDR value
-    let stack_addr = VarnodeData {
-        address: Address {
-            offset: common::INITIAL_STACK,
-            address_space: sleigh
-                .address_space_by_name("ram")
-                .expect("failed to find ram"),
-        },
-        size: common::EXIT_IP_ADDR.to_le_bytes().len(),
-    };
-    memory
-        .write(&stack_addr, common::EXIT_IP_ADDR.into())
-        .expect("failed to initialize stack");
-
-    let handler = arch::aarch64::processor::ProcessorHandler::new(&sleigh);
-    let emulator = TracingEmulator::new(StandardPcodeEmulator::new(sleigh.address_spaces()));
-    let mut processor = Processor::new(memory, emulator, handler);
-
-    loop {
-        processor.step(&sleigh)?;
-
-        // Check if PC is the magic value
-        if matches!(processor.state(), ProcessorState::Decode(_)) {
-            let disassembly = processor.disassemble(&sleigh)?;
-            let encoded_instr = processor
-                .memory()
-                .read(&disassembly.origin)?
-                .into_le_bytes()
-                .map(|byte| u8::try_from(byte).map_or("xx".to_string(), |b| format!("{b:02x}")))
-                .collect::<Vec<_>>()
-                .join(" ");
-
-            println!("Encoded instruction from memory: {encoded_instr}");
-            println!("Decoded: {disassembly}");
-        }
-
-        let instruction_pointer: u64 = processor
-            .memory()
-            .read(&pc)?
-            .try_into()
-            .expect("failed to concretize pc register");
-
-        if instruction_pointer == common::EXIT_IP_ADDR
-            && matches!(processor.state(), ProcessorState::Fetch)
-        {
-            break;
-        }
-    }
-
-    let return_register = sleigh
-        .register_from_name("x0")
-        .expect("failed to get x0 register");
-    let return_value: u64 = processor
-        .memory()
-        .read(&return_register)?
-        .try_into()
-        .expect("failed to concretize return register");
-    assert_eq!(
-        return_value, 0,
-        "unexpected return value: {return_value:016x}"
-    );
-
-    processor
-        .emulator()
-        .executed_instructions()
-        .into_iter()
-        .for_each(|(opcode, count)| println!("Executed {opcode:?}: {count}"));
-
-    // Currently the following p-code instructions are not covered by this test:
-    //
-    // Piece
-    // Bool(Xor)
-    // Int(LessThanOrEqual(Signed))
-    // Int(LessThanOrEqual(Unsigned))
-    // Int(GreaterThan(Signed))
-    // Int(GreaterThan(Unsigned))
-    // Int(GreaterThanOrEqual(Signed))
-    // Int(GreaterThanOrEqual(Unsigned))
-    // BranchIndirect -- though technically this is covered via Return
-    assert_eq!(processor.emulator().executed_instructions().len(), 33);
-    Ok(())
-}
-
-#[test]
 fn z3_integration() -> processor::Result<()> {
     let sleigh = x86_64_sleigh().expect("failed to build sleigh");
     let emulator = StandardPcodeEmulator::new(sleigh.address_spaces());
@@ -441,10 +228,10 @@ fn z3_integration() -> processor::Result<()> {
     let write_register = |memory: &mut Memory, name: &str, data: &[u8]| {
         let register = sleigh
             .register_from_name(name)
-            .expect(&format!("invalid register {name}"));
+            .unwrap_or_else(|_| panic!("invalid register {name}"));
         memory
-            .write(&register, data.into_iter().copied().collect())
-            .expect(&format!("failed to write register {name}"));
+            .write(&register, data.iter().copied().collect())
+            .unwrap_or_else(|_| panic!("failed to write register {name}"));
     };
 
     // Small program: if x > 0 { x + x } else { x * x }


### PR DESCRIPTION
This small reorganization helps consolidate common code and tests. For example, this clarifies that the tracing emulator is only intended for tracking pcode coverage.

Also addressed some outstanding clippy issues.