### PR TITLE
Add support for building Sleigh from sla file contents

### DIFF
--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsla"
 description = "Rust bindings to Ghidra Sleigh library libsla"
-version = "0.4.0"
+version = "0.4.1"
 
 authors.workspace = true
 edition.workspace = true 
@@ -10,4 +10,4 @@ repository.workspace = true
 
 [dependencies]
 thiserror.workspace = true
-libsla-sys = { version = "0.1" }
+libsla-sys = { version = "0.1.2" }

--- a/crates/libsla/src/sleigh.rs
+++ b/crates/libsla/src/sleigh.rs
@@ -587,6 +587,31 @@ impl<P> GhidraSleighBuilder<MissingSpec, P> {
     }
 }
 
+impl GhidraSleighBuilder<MissingSpec, HasSpec> {
+    pub fn build(self, sla: impl AsRef<[u8]>) -> Result<GhidraSleigh> {
+        let_cxx_string!(sla = sla);
+        let mut sleigh = sys::new_sleigh(sys::new_context_internal());
+
+        sleigh
+            .pin_mut()
+            .initialize_from_sla(&sla)
+            .map_err(|err| Error::DependencyError {
+                message: Cow::Borrowed("failed to initialize Ghidra sleigh"),
+                source: Box::new(err),
+            })?;
+
+        sleigh
+            .pin_mut()
+            .parse_processor_config(&self.store)
+            .map_err(|err| Error::DependencyError {
+                message: Cow::Borrowed("failed to import processor config"),
+                source: Box::new(err),
+            })?;
+
+        Ok(GhidraSleigh { sleigh })
+    }
+}
+
 impl GhidraSleighBuilder<HasSpec, HasSpec> {
     pub fn build(mut self) -> Result<GhidraSleigh> {
         let mut sleigh = sys::new_sleigh(sys::new_context_internal());


### PR DESCRIPTION
This adds a method to `GhidraSleighBuilder` that can build `GhidraSleigh` from the `.sla` file contents directly instead of needing the contents to exist in a file. The latter was a change introduced in Ghidra 11.1 that unfortunately complicated `.sla` configuration management in this crate.