### PR TITLE
Update libsla README.md to reflect sleigh-config crate release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Nothing here yet.
 
+## libsla-0.4.2
+
+### Changed
+
+* Updated README.md to reflect release of the [sleigh-config](https://crates.io/crates/sleigh-config)
+crate. This crate removes the need to manually compile Ghidra `.slaspec` files, which in most cases
+should eliminate the need to reference the Ghidra repository.
+
 ## libsla-0.4.1
 
 ### Added

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsla"
 description = "Rust bindings to Ghidra Sleigh library libsla"
-version = "0.4.1"
+version = "0.4.2"
 
 authors.workspace = true
 edition.workspace = true 

--- a/crates/libsla/README.md
+++ b/crates/libsla/README.md
@@ -4,49 +4,32 @@ This crate provides Rust bindings to the Sleigh library libsla found in [NSA's G
 which disassembles processor instructions into p-code. This enables binary analysis programs to
 analyze arbitrary programs by targeting p-code instead of specific instruction set architectures.
 
-# Requirements
+# Configuration
 
-A Sleigh instance requires a _compiled sleigh specification_ (.sla) and a _processor specification_
-(.pspec).
+Building a Sleigh instance requires a _compiled sleigh specification_ (.sla) and a
+_processor specification_ (.pspec). These can be obtained from the
+[sleigh-config](https://crates.io/crates/sleigh-config) crate.
 
-## Sleigh Specification (.sla)
+Processor specification files are responsible for filling in context data defined in sla files. For
+example, `addrsize` is variable context defined in the x86 sla file. The x86-64 pspec defines this
+as `2` for 64-bit addressing while the x86 pspec defines this as `1` for 32-bit addressing. Note the
+sla file is responsible for interpreting the meaning of these values.
 
-The relevant .slaspec file must be compiled using the Sleigh compiler to generate the appropriate
-.sla file for the target architecture. Existing .slaspec files can be found in the
-[Ghidra processors repository](https://github.com/NationalSecurityAgency/ghidra/tree/stable/Ghidra/Processors).
+## Custom Sleigh Specification
 
-## Sleigh Compiler
-
-The sleigh compiler can be invoked from Rust code using the [sleigh-compiler](https://crates.io/crates/sleigh-compiler) crate.
-Alternatively the original compiler can be built from the
+Custom sleigh specification files can be compiled from Rust using the
+[sleigh-compiler](https://crates.io/crates/sleigh-compiler) crate. Alternatively the original
+compiler can be built from the
 [Ghidra decompiler source](https://github.com/NationalSecurityAgency/ghidra/blob/stable/Ghidra/Features/Decompiler/src/decompile/cpp)
 using `make sleigh_opt`.
 
-## Processor Specification (.pspec)
-
-Processor specification files can be found in
-[Ghidra processors repository](https://github.com/NationalSecurityAgency/ghidra/tree/stable/Ghidra/Processors).
-These are responsible for filling in context data defined in sla files. For example, `addrsize` is
-variable context defined in the x86 sla file. The x86-64 pspec defines this as `2` for 64-bit
-addressing while the x86 pspec defines this as `1` for 32-bit addressing. Note the sla file is 
-responsible for interpreting the meaning of these values.
-
 # Example
 
-This gives an overview of the general structure for disassembling code into p-code. For a working
-example using x86-64 see the [sleigh unit tests](./src/sleigh.rs).
-
 ```rust
-// Compiled from x86-64.slaspec in Ghidra repository
-let slaspec = std::fs::read("x86-64.sla")?;
-
-// Located in Ghidra repository. No compilation necessary.
-let pspec = std::fs::read_to_string("x86-64.pspec")?;
-
-// Construct new sleigh instance
+// Build Sleigh with configuration files from sleigh-config crate
 let sleigh = GhidraSleigh::builder()
-    .processor_spec(&pspec)?
-    .build(&slaspec)?;
+    .processor_spec(sleigh_config::processor_x86::PSPEC_X86_64)?
+    .build(sleigh_config::processor_x86::SLA_X86_64)?;
 
 // The instruction reader is defined by the user and implements the LoadImage trait.
 let instruction_reader = InstructionReader::new();
@@ -57,6 +40,5 @@ let address_space = sleigh.default_code_space();
 let instruction_address = Address::new(instruction_offset, address_space);
 
 // Disassemble!
-let pcode_disassembly = sleigh.disassemble_pcode(&instruction_reader, instruction_address).expect("disassembly failed");
+let pcode_disassembly = sleigh.disassemble_pcode(&instruction_reader, instruction_address)?;
 ```
-


### PR DESCRIPTION
This change updates the README.md to suggest using the configuration files from the sleigh-config crate instead of manually compiling them. Pointers to the compiler are kept in for instructions on custom specifications.