### PR TITLE
Add support for building libsla-sys with fuzzing instrumentation

### DIFF
--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsla"
 description = "Rust bindings to Ghidra Sleigh library libsla"
-version = "0.4.3"
+version = "0.4.2"
 
 authors.workspace = true
 edition.workspace = true 


### PR DESCRIPTION
This change adds a feature flag `fuzzing` to `libsla` to enable building `libsla-sys` with fuzzing support.