### PR TITLE
Add support for decoding raw sla format

### DIFF
--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -14,3 +14,7 @@ fuzzing = ["libsla-sys/fuzzing"]
 [dependencies]
 thiserror.workspace = true
 libsla-sys = { version = "0.1.3" }
+
+[dev-dependencies]
+flate2 = "1.1"
+sleigh-config = "0.1"

--- a/crates/libsla/Cargo.toml
+++ b/crates/libsla/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsla"
 description = "Rust bindings to Ghidra Sleigh library libsla"
-version = "0.4.2"
+version = "0.4.3"
 
 authors.workspace = true
 edition.workspace = true 

--- a/crates/libsla/src/tests/sleigh.rs
+++ b/crates/libsla/src/tests/sleigh.rs
@@ -1,5 +1,23 @@
-use crate::*;
+use std::io::Read;
+
+use flate2::{
+    Compression,
+    bufread::{ZlibDecoder, ZlibEncoder},
+};
 use libsla_sys::sys;
+use sleigh_config::processor_x86::PSPEC_X86_64 as PROCESSOR_SPEC;
+use sleigh_config::processor_x86::SLA_X86_64 as SLEIGH_SPEC;
+
+use crate::*;
+
+struct InstructionLoader;
+
+impl LoadImage for InstructionLoader {
+    fn instruction_bytes(&self, _data: &VarnodeData) -> std::result::Result<Vec<u8>, String> {
+        // PUSH RBP
+        Ok(vec![0x55])
+    }
+}
 
 #[test]
 pub fn addr_space_type() -> Result<()> {
@@ -33,4 +51,94 @@ pub fn addr_space_type() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[test]
+fn build_sla() -> Result<()> {
+    // Confirm the original spec builds successfully
+    let sleigh = GhidraSleigh::builder()
+        .processor_spec(PROCESSOR_SPEC)?
+        .build(SLEIGH_SPEC)?;
+    verify_sleigh(sleigh);
+    Ok(())
+}
+
+#[test]
+fn build_sla_recompressed() -> Result<()> {
+    const SLA_VERSION: u8 = 4;
+    const HEADER_SIZE: usize = 4;
+
+    assert!(SLEIGH_SPEC.len() > HEADER_SIZE);
+    assert_eq!(SLEIGH_SPEC[0], b's');
+    assert_eq!(SLEIGH_SPEC[1], b'l');
+    assert_eq!(SLEIGH_SPEC[2], b'a');
+    assert_eq!(SLEIGH_SPEC[3], SLA_VERSION);
+
+    // Decompress input
+    let mut decoder = ZlibDecoder::new(&SLEIGH_SPEC[4..]);
+    let mut decoded = Vec::new();
+    decoder
+        .read_to_end(&mut decoded)
+        .expect("failed to decode zlib compressed sla spec data");
+    assert!(!decoded.is_empty(), "decoded data should not be empty");
+
+    // Recompress input
+    let mut encoder = ZlibEncoder::new(std::io::Cursor::new(decoded), Compression::fast());
+    let mut compressed_data = Vec::with_capacity(4096);
+    encoder
+        .read_to_end(&mut compressed_data)
+        .expect("failed to compress data");
+
+    let mut test_spec = Vec::with_capacity(compressed_data.len() + HEADER_SIZE);
+    test_spec.push(b's');
+    test_spec.push(b'l');
+    test_spec.push(b'a');
+    test_spec.push(SLA_VERSION);
+    test_spec.append(&mut compressed_data);
+
+    // Confirm the original spec builds successfully
+    let sleigh = GhidraSleigh::builder()
+        .processor_spec(PROCESSOR_SPEC)?
+        .build(test_spec)?;
+    verify_sleigh(sleigh);
+    Ok(())
+}
+
+#[test]
+fn build_raw_sla() -> Result<()> {
+    const SLA_VERSION: u8 = 4;
+    const HEADER_SIZE: usize = 4;
+
+    assert!(SLEIGH_SPEC.len() > HEADER_SIZE);
+    assert_eq!(SLEIGH_SPEC[0], b's');
+    assert_eq!(SLEIGH_SPEC[1], b'l');
+    assert_eq!(SLEIGH_SPEC[2], b'a');
+    assert_eq!(SLEIGH_SPEC[3], SLA_VERSION);
+
+    // Decompress input
+    let mut decoder = ZlibDecoder::new(&SLEIGH_SPEC[4..]);
+    let mut decoded = Vec::new();
+    decoder
+        .read_to_end(&mut decoded)
+        .expect("failed to decode zlib compressed sla spec data");
+    assert!(!decoded.is_empty(), "decoded data should not be empty");
+
+    let sleigh = GhidraSleigh::builder()
+        .processor_spec(PROCESSOR_SPEC)?
+        .sla_decoder(SlaDecoder::Raw)
+        .build(&decoded)?;
+    verify_sleigh(sleigh);
+    Ok(())
+}
+
+fn verify_sleigh(sleigh: GhidraSleigh) {
+    let loader = InstructionLoader;
+    let address = Address::new(sleigh.default_code_space(), 0);
+    let disassembly = sleigh
+        .disassemble_native(&loader, address)
+        .expect("disassembly should succeed");
+
+    let instruction = &disassembly.instructions[0];
+    assert_eq!(instruction.mnemonic, "PUSH");
+    assert_eq!(instruction.body, "RBP");
 }

--- a/crates/libsla/src/tests/sleigh.rs
+++ b/crates/libsla/src/tests/sleigh.rs
@@ -96,7 +96,7 @@ fn build_sla_recompressed() -> Result<()> {
     test_spec.push(SLA_VERSION);
     test_spec.append(&mut compressed_data);
 
-    // Confirm the original spec builds successfully
+    // Confirm the recompressed spec with header builds successfully
     let sleigh = GhidraSleigh::builder()
         .processor_spec(PROCESSOR_SPEC)?
         .build(test_spec)?;


### PR DESCRIPTION
This adds `GhidraSleighBuilder::sla_decoder` which can be used when not loading the sla spec from the document store. This method can be used to specify the decoding format, either `sla` (the normal format used by Ghidra) or `raw`, a modification of the standard format that omits the header and does not compress the data. The `sla` format is still the default format.