### PR TITLE
Upgrade libsla dependency to version 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "autocfg"
@@ -88,9 +88,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -272,9 +272,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cxx"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f81de88da10862f22b5b3a60f18f6f42bbe7cb8faa24845dd7b1e4e22190e77"
+checksum = "4e9c4fe7f2f5dc5c62871a1b43992d197da6fa1394656a94276ac2894a90a6fe"
 dependencies = [
  "cc",
  "cxx-build",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edd58bf75c3fdfc80d79806403af626570662f7b6cc782a7fabe156166bd6d6"
+checksum = "b5cf2909d37d80633ddd208676fc27c2608a7f035fff69c882421168038b26dd"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd46bf2b541a4e0c2d5abba76607379ee05d68e714868e3cb406dc8d591ce2d2"
+checksum = "077f5ee3d3bfd8d27f83208fdaa96ddd50af7f096c77077cc4b94da10bfacefd"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -316,15 +316,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c79b68f6a3a8f809d39b38ae8af61305a6113819b19b262643b9c21353b92d9"
+checksum = "b0108748615125b9f2e915dfafdffcbdabbca9b15102834f6d7e9a768f2f2864"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862b7fdb048ff9ef0779a0d0a03affd09746c4c875543746b640756be9cff2af"
+checksum = "e6e896681ef9b8dc462cfa6961d61909704bde0984b30bcb4082fe102b478890"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -483,9 +483,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "libsla"
-version = "0.4.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133ab3ca2facbd2c52d1f2e4bae0513eea72e47ebd192083436c302a2a06ed8a"
+checksum = "709e0b5fa5e2dc7c08224e323f464fbb84d9b9b7452f6587805d1da914fdf652"
 dependencies = [
  "libsla-sys",
  "thiserror",
@@ -554,9 +554,9 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "minimal-lexical"
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -747,9 +747,9 @@ checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -757,18 +757,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -876,18 +876,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -965,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -978,18 +978,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1001,14 +1001,14 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1030,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1083,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ repository = "https://github.com/mnemonikr/symbolic-pcode"
 [workspace.dependencies]
 thiserror = "2.0"
 log = "0.4"
-
-[patch.crates-io]
-libsla-sys = { path = "../mnemonikr/libsla-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ repository = "https://github.com/mnemonikr/symbolic-pcode"
 [workspace.dependencies]
 thiserror = "2.0"
 log = "0.4"
+
+[patch.crates-io]
+libsla-sys = { path = "../mnemonikr/libsla-sys" }

--- a/crates/pcode/Cargo.toml
+++ b/crates/pcode/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-libsla = "0.4.3"
+libsla = "1"
 pcode-ops = { path = "../pcode-ops" }
 thiserror.workspace = true
 log.workspace = true

--- a/crates/pcode/src/mem.rs
+++ b/crates/pcode/src/mem.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, rc::Rc};
 
 use thiserror;
 
-use libsla::{Address, AddressSpaceId, AddressSpaceType, LoadImage, VarnodeData};
+use libsla::{Address, AddressSpaceId, AddressSpaceType, InstructionLoader, VarnodeData};
 use pcode_ops::{BitwisePcodeOps, PcodeOps, convert::PcodeValue};
 
 /// Memory result type
@@ -449,9 +449,9 @@ impl<'b, 'd, M: VarnodeDataStore + Default> MemoryTree<'b, 'd, M> {
 /// Memory that holds binary-encoded executable instructions.
 pub struct ExecutableMemory<'a, M: VarnodeDataStore>(pub &'a M);
 
-/// Implementation of the LoadImage trait to enable loading instructions from memory
-impl<M: VarnodeDataStore> LoadImage for ExecutableMemory<'_, M> {
-    fn instruction_bytes(&self, input: &VarnodeData) -> std::result::Result<Vec<u8>, String> {
+/// Implementation of the InstructionLoader trait to enable loading instructions from memory
+impl<M: VarnodeDataStore> InstructionLoader for ExecutableMemory<'_, M> {
+    fn load_instruction_bytes(&self, input: &VarnodeData) -> std::result::Result<Vec<u8>, String> {
         let value = self.0.read(input);
 
         // The number of bytes requested may exceed valid data in memory.

--- a/crates/pcode/src/processor.rs
+++ b/crates/pcode/src/processor.rs
@@ -4,7 +4,8 @@ use thiserror;
 use crate::emulator::{ControlFlow, Destination, PcodeEmulator};
 use crate::mem::{ExecutableMemory, MemoryBranch, VarnodeDataStore};
 use libsla::{
-    Address, AddressSpace, AssemblyInstruction, Disassembly, PcodeInstruction, Sleigh, VarnodeData,
+    Address, AddressSpace, NativeDisassembly, PcodeDisassembly, PcodeInstruction, Sleigh,
+    VarnodeData,
 };
 
 // TODO Emulator can also have memory access errors. Probably better to write a custom
@@ -104,7 +105,7 @@ impl<E: PcodeEmulator + Clone, M: VarnodeDataStore + Default, H: ProcessorRespon
         &self.state
     }
 
-    pub fn disassemble(&self, sleigh: &impl Sleigh) -> Result<Disassembly<AssemblyInstruction>> {
+    pub fn disassemble(&self, sleigh: &impl Sleigh) -> Result<NativeDisassembly> {
         if let ProcessorState::Decode(d) = &self.state {
             d.disassemble(sleigh, ExecutableMemory(&self.memory))
         } else {
@@ -322,7 +323,7 @@ impl DecodeInstruction {
         &self,
         sleigh: &impl Sleigh,
         memory: ExecutableMemory<M>,
-    ) -> Result<Disassembly<AssemblyInstruction>> {
+    ) -> Result<NativeDisassembly> {
         let assembly = sleigh
             .disassemble_native(&memory, self.address.clone())
             .map_err(Error::InstructionDecoding)?;
@@ -333,16 +334,16 @@ impl DecodeInstruction {
 
 #[derive(Clone, Debug)]
 pub struct PcodeExecution {
-    pcode: Disassembly<PcodeInstruction>,
+    pcode: PcodeDisassembly,
     index: usize,
 }
 
 impl PcodeExecution {
-    pub fn new(pcode: Disassembly<PcodeInstruction>) -> Self {
+    pub fn new(pcode: PcodeDisassembly) -> Self {
         Self { pcode, index: 0 }
     }
 
-    pub fn pcode(&self) -> &Disassembly<PcodeInstruction> {
+    pub fn pcode(&self) -> &PcodeDisassembly {
         &self.pcode
     }
 

--- a/crates/pcode/src/tests/mem.rs
+++ b/crates/pcode/src/tests/mem.rs
@@ -363,7 +363,7 @@ fn memory_tree_without_branches() -> Result<()> {
 }
 
 #[test]
-fn executable_memory_instruction_bytes() -> Result<()> {
+fn executable_memory_load_instruction_bytes() -> Result<()> {
     // Setup memory with an address space
     let value = 0xbe;
     let mut memory = GenericMemory::<Pcode128>::default();
@@ -373,7 +373,7 @@ fn executable_memory_instruction_bytes() -> Result<()> {
     memory.write(&varnode, value.into())?;
     let exec_mem = ExecutableMemory(&memory);
     let data = exec_mem
-        .instruction_bytes(&varnode)
+        .load_instruction_bytes(&varnode)
         .expect("failed to get instruction bytes");
 
     assert_eq!(data.len(), 1);
@@ -388,7 +388,7 @@ fn executable_memory_undefined_data() -> Result<()> {
     let varnode = VarnodeData::new(Address::new(address_space(0), 0), 1);
     let exec_mem = ExecutableMemory(&memory);
 
-    let result = exec_mem.instruction_bytes(&varnode);
+    let result = exec_mem.load_instruction_bytes(&varnode);
     let msg = result.expect_err("result should be undefined data error");
     assert_eq!(
         msg,
@@ -404,7 +404,7 @@ fn executable_memory_symbolic_data() -> Result<()> {
     memory.write(&varnode, SymbolicValue::default())?;
     let exec_mem = ExecutableMemory(&memory);
 
-    let result = exec_mem.instruction_bytes(&varnode);
+    let result = exec_mem.load_instruction_bytes(&varnode);
     assert!(matches!(result, Err(msg) if msg == "symbolic byte"));
 
     Ok(())
@@ -425,7 +425,7 @@ fn executable_memory_partial_undefined_data() -> Result<()> {
     varnode.size += 1;
 
     let data = exec_mem
-        .instruction_bytes(&varnode)
+        .load_instruction_bytes(&varnode)
         .expect("failed to get instruction bytes");
 
     assert_eq!(data.len(), 1);

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -140,7 +140,7 @@ fn hello_world_aarch64_linux() -> processor::Result<()> {
                 .join(" ");
 
             println!("Encoded instruction from memory: {encoded_instr}");
-            println!("Decoded: {instr}", instr = disassembly.instructions[0]);
+            println!("Decoded: {instr}", instr = disassembly.instruction);
         }
 
         if matches!(processor.state(), ProcessorState::Halt) {


### PR DESCRIPTION
A few breaking changes in this major release that required minor source code changes to accommodate.