### PR TITLE
Aiger update to remove dependency on sym::SymbolicBit

### DIFF
--- a/crates/sym/src/convert.rs
+++ b/crates/sym/src/convert.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use crate::aiger;
 use crate::buf::{SymbolicBitBuf, SymbolicByte};
 use crate::sym::{self, ConcretizationError, SymbolicBit, SymbolicBitVec};
@@ -338,13 +336,13 @@ impl_little_endian!(u32);
 impl_little_endian!(u16);
 impl_little_endian!(u8);
 
-impl From<&SymbolicBit> for aiger::SymbolicBit<SymbolicBit> {
-    fn from(value: &SymbolicBit) -> Self {
+impl<'a> From<&'a SymbolicBit> for aiger::SymbolicBit<'a, SymbolicBit> {
+    fn from(value: &'a SymbolicBit) -> Self {
         match value {
             SymbolicBit::Literal(b) => aiger::SymbolicBit::Literal(*b),
             SymbolicBit::Variable(id) => aiger::SymbolicBit::Variable(*id),
-            SymbolicBit::Not(x) => aiger::SymbolicBit::Not(Rc::as_ptr(x)),
-            SymbolicBit::And(x, y) => aiger::SymbolicBit::And(Rc::as_ptr(x), Rc::as_ptr(y)),
+            SymbolicBit::Not(x) => aiger::SymbolicBit::Not(x.as_ref()),
+            SymbolicBit::And(x, y) => aiger::SymbolicBit::And(x.as_ref(), y.as_ref()),
         }
     }
 }


### PR DESCRIPTION
This updates the `sym::aiger` module to remove its dependency on `sym::SymbolicBit`. With this change the module can be published independently as its own crate.