### PR TITLE
Use Rc::unwrap_or_clone when double negating SymbolicBit

### DIFF
--- a/crates/sym/src/sym.rs
+++ b/crates/sym/src/sym.rs
@@ -58,10 +58,7 @@ impl std::ops::Not for SymbolicBit {
         match self {
             SymbolicBit::Literal(false) => SymbolicBit::Literal(true),
             SymbolicBit::Literal(true) => SymbolicBit::Literal(false),
-
-            // TODO: Use Rc::unwrap_or_clone(y) once feature is stable
-            // See https://github.com/rust-lang/rust/issues/93610
-            SymbolicBit::Not(y) => (*y).clone(),
+            SymbolicBit::Not(y) => Rc::unwrap_or_clone(y),
             _ => SymbolicBit::Not(Rc::new(self)),
         }
     }


### PR DESCRIPTION
This avoids unnecessarily cloning the inner value if this is the only reference to it.