### PR TITLE
Update rustfmt and Cargo.lock

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-style_edition = "2024"
+edition = "2024"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,10 +13,6 @@ dependencies = [
 
 [[package]]
 name = "aiger-circuit"
-version = "0.1.0"
-
-[[package]]
-name = "aiger-circuit"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8202549285e88b2ed41e06741cf2c27c9336704e4be2f42ae03f36b93cdf4102"
@@ -838,7 +834,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 name = "sym"
 version = "0.1.0"
 dependencies = [
- "aiger-circuit 1.0.1",
+ "aiger-circuit",
  "pcode-ops",
  "thiserror",
 ]
@@ -877,7 +873,7 @@ dependencies = [
 name = "tests-integration"
 version = "0.0.0"
 dependencies = [
- "aiger-circuit 1.0.1",
+ "aiger-circuit",
  "elf",
  "escargot",
  "flexi_logger",


### PR DESCRIPTION
The `style_edition` is not stable for rustfmt.toml but `edition` is