### PR TITLE
Bump MSRV to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["mnemonikr"]
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/mnemonikr/symbolic-pcode"
-rust-version = "1.87"
+rust-version = "1.88"
 
 [workspace.dependencies]
 thiserror = "2.0"


### PR DESCRIPTION
Previous PR bumped the Github action MSRV to 1.88. This bumps the MSRV in Cargo.toml.