### PR TITLE
Address clippy nits regarding is_multiple_of

### DIFF
--- a/crates/sym/src/vec.rs
+++ b/crates/sym/src/vec.rs
@@ -54,7 +54,7 @@ impl SymbolicBitVec {
     }
 
     pub fn into_bytes(self) -> Vec<SymbolicByte> {
-        assert_eq!(self.bits.len() % 8, 0);
+        assert!(self.bits.len().is_multiple_of(8));
         let num_bytes = self.bits.len() / 8;
 
         let mut bits = [FALSE; 8];
@@ -62,7 +62,7 @@ impl SymbolicBitVec {
 
         for (i, bit) in self.bits.into_iter().enumerate() {
             bits[i % 8] = bit;
-            if (i + 1) % 8 == 0 {
+            if (i + 1).is_multiple_of(8) {
                 bytes.push(bits.into());
                 bits = [FALSE; 8];
             }
@@ -72,7 +72,7 @@ impl SymbolicBitVec {
     }
 
     pub fn into_parts(self, num_bits: usize) -> Vec<Self> {
-        assert_eq!(self.bits.len() % num_bits, 0);
+        assert!(self.bits.len().is_multiple_of(8));
         let mut parts = Vec::new();
         let mut remainder = self;
         while remainder.len() > num_bits {

--- a/crates/sym/src/vec/convert.rs
+++ b/crates/sym/src/vec/convert.rs
@@ -6,7 +6,7 @@ impl TryInto<Vec<SymbolicByte>> for SymbolicBitVec {
     type Error = String;
 
     fn try_into(self) -> Result<Vec<SymbolicByte>, Self::Error> {
-        if self.bits.len() % 8 == 0 {
+        if self.bits.len().is_multiple_of(8) {
             Ok(self.into_bytes())
         } else {
             Err(format!(


### PR DESCRIPTION
Prefer `x.is_multiple_of(8)` instead of `x % 8 == 0`