### PR TITLE
Fix CBRANCH emulator condition evaluation

### DIFF
--- a/crates/pcode/src/emulator.rs
+++ b/crates/pcode/src/emulator.rs
@@ -466,17 +466,20 @@ impl StandardPcodeEmulator {
     /// is not treated as a variable but as an address and is interpreted in the same way.
     /// Furthermore, a constant space address is also interpreted as a relative address so that a
     /// CBRANCH can do p-code relative branching. See the discussion for the BRANCH operation.
-    fn conditional_branch(
+    fn conditional_branch<M: VarnodeDataStore>(
         &self,
-        memory: &mut impl VarnodeDataStore,
+        memory: &mut M,
         instruction: &PcodeInstruction,
     ) -> Result<ControlFlow> {
         require_num_inputs(instruction, 2)?;
         require_has_output(instruction, false)?;
         require_input_size_equals(instruction, 1, 1)?;
 
+        let zero = PcodeValue::<M::Value>::from(0u8);
+        let condition = memory.read(&instruction.inputs[1])?;
+
         Ok(ControlFlow::ConditionalBranch {
-            condition: memory.read_bit(&instruction.inputs[1])?.try_into().ok(),
+            condition: condition.not_equals(zero.into_inner()).try_into().ok(),
             condition_origin: instruction.inputs[1].clone(),
             destination: Self::branch_destination(&instruction.inputs[0]),
         })

--- a/crates/pcode/src/tests/emulator.rs
+++ b/crates/pcode/src/tests/emulator.rs
@@ -1591,6 +1591,54 @@ fn conditional_branch_absolute() -> Result<()> {
 }
 
 #[test]
+fn conditional_branch_when_condition_neither_zero_nor_one() -> Result<()> {
+    let mut memory = GenericMemory::<Pcode128>::default();
+    let mut emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);
+    let destination_input = VarnodeData {
+        address: Address {
+            address_space: processor_address_space(),
+            offset: 0xDEADBEEF,
+        },
+        size: 0, // This value is irrelevant
+    };
+
+    // Condition has low bit set to 0, but is non-zero value. Should be considered true
+    let condition_input = write_value(&mut memory, 1, 0x10u8)?;
+    let instruction = PcodeInstruction {
+        address: Address {
+            address_space: processor_address_space(),
+            offset: 0xFF00000000,
+        },
+        op_code: OpCode::BranchConditional,
+        inputs: vec![destination_input.clone(), condition_input.clone()],
+        output: None,
+    };
+
+    let control_flow = emulator.emulate(&mut memory, &instruction)?;
+    let expected_destination = Destination::MachineAddress(Address {
+        address_space: processor_address_space(),
+        offset: 0xDEADBEEF,
+    });
+    match control_flow {
+        ControlFlow::ConditionalBranch {
+            condition_origin,
+            condition,
+            destination,
+        } => {
+            assert_eq!(condition_origin, condition_input);
+            assert_eq!(condition, Some(true));
+            assert_eq!(
+                destination, expected_destination,
+                "invalid branch destination"
+            );
+        }
+        _ => panic!("unexpected control flow instruction: {control_flow:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
 fn conditional_branch_pcode_relative() -> Result<()> {
     let mut memory = GenericMemory::<Pcode128>::default();
     let mut emulator = StandardPcodeEmulator::new(vec![processor_address_space()]);


### PR DESCRIPTION
The emulator was attempting to extract a single bit for the condition evaluation. However, the documentation for CBRANCH says this the condition should evaluate to true if the condition _byte_ is non-zero.

Resolves #241 